### PR TITLE
Infrastructure updates

### DIFF
--- a/addrmap.c
+++ b/addrmap.c
@@ -229,7 +229,20 @@ static void add_to_hash_table(struct cache_entry *c, uint32_t hash4,
 /**
  * @brief Initialize address translation cache
  *  
- * TODO Document how the cache works better
+ * This function initializes the two hash sets used
+ * for caching address translations.
+ * If it has not been done already, this function allocates
+ * `gcfg->cache_size` cache entries for the memory pool.
+ * 
+ * The address translation state is a set of IPv4-IPv6 address pairs.
+ * There is additional metada as well: see `struct cache_entry`.
+ * These pairs are stored in the linked list `gcfg->list`.
+ * The cache is two hash sets (`gcfg->hash_table4` and `gcfg->hash_table6`)
+ * that let Tayga query elements of this set using the IPv4
+ * or the IPv6 address.
+ * These hash sets use separate-chaining with a fixed bucket size
+ * (configurable as `gcfg->cache_size`),
+ * so the code here must initialize each of the buckets.
  *
  */
 void create_cache(void)
@@ -335,7 +348,7 @@ struct map6 *find_map6(const struct in6_addr *addr6)
  * @brief Insert an IPv4 entry into the cache
  *  
  * @param map4 Cache entry to add
- * @param conflict Pointer to return conflicting object
+ * @param[out] conflict Pointer to return conflicting object
  * @returns -1 on conflict
  */
 int insert_map4(struct map4 *m, struct map4 **conflict)
@@ -363,7 +376,7 @@ conflict:
  * @brief Insert an IPv6 entry into the cache
  *  
  * @param map6 Cache entry to add
- * @param conflict Pointer to return conflicting object
+ * @param[out] conflict Pointer to return conflicting object
  * @returns -1 on conflict
  */
 int insert_map6(struct map6 *m, struct map6 **conflict)

--- a/nat64.c
+++ b/nat64.c
@@ -18,6 +18,44 @@
 
 #include "tayga.h"
 
+/* Protocol headers */
+struct ip6_data {
+    struct tun_pi pi;
+    struct ip6 ip6;
+    struct ip6_frag ip6_frag;
+};
+
+struct ip6_icmp {
+    struct tun_pi pi;
+    struct ip6 ip6;
+    struct icmp icmp;
+};
+
+struct ip6_error {
+    struct tun_pi pi;
+    struct ip6 ip6;
+    struct icmp icmp;
+    struct ip6 ip6_em;
+};
+
+struct ip4_data {
+    struct tun_pi pi;
+    struct ip4 ip4;
+};
+
+struct ip4_icmp {
+    struct tun_pi pi;
+    struct ip4 ip4;
+    struct icmp icmp;
+};
+
+struct ip4_error {
+    struct tun_pi pi;
+    struct ip4 ip4;
+    struct icmp icmp;
+    struct ip4 ip4_em;
+};
+
 extern struct config *gcfg;
 
 static uint16_t ip_checksum(void *d, int c)
@@ -91,11 +129,7 @@ static void host_send_icmp4(uint8_t tos, struct in_addr *src,
 		struct in_addr *dest, struct icmp *icmp,
 		uint8_t *data, int data_len)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip4 ip4;
-		struct icmp icmp;
-	} __attribute__ ((__packed__)) header;
+	struct ip4_icmp header;
 	struct iovec iov[2];
 
 	TUN_SET_PROTO(&header.pi,  ETH_P_IP);
@@ -232,11 +266,7 @@ static int xlate_payload_4to6(struct pkt *p, struct ip6 *ip6)
 
 static void xlate_4to6_data(struct pkt *p)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip6 ip6;
-		struct ip6_frag ip6_frag;
-	} header;
+	struct ip6_data header;
 	struct cache_entry *src = NULL, *dest = NULL;
 	struct iovec iov[2];
 	int no_frag_hdr = 0;
@@ -419,12 +449,7 @@ static unsigned int est_mtu(unsigned int too_big)
 
 static void xlate_4to6_icmp_error(struct pkt *p)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip6 ip6;
-		struct icmp icmp;
-		struct ip6 ip6_em;
-	} header;
+	struct ip6_error header;
 	struct iovec iov[2];
 	struct pkt p_em;
 	uint32_t mtu;
@@ -633,11 +658,7 @@ static void host_send_icmp6(uint8_t tc, struct in6_addr *src,
 		struct in6_addr *dest, struct icmp *icmp,
 		uint8_t *data, int data_len)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip6 ip6;
-		struct icmp icmp;
-	} header;
+	struct ip6_icmp header;
 	struct iovec iov[2];
 
 	TUN_SET_PROTO(&header.pi,  ETH_P_IPV6);
@@ -799,10 +820,7 @@ static int xlate_payload_6to4(struct pkt *p, struct ip4 *ip4)
 
 static void xlate_6to4_data(struct pkt *p)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip4 ip4;
-	} header;
+	struct ip4_data header;
 	struct cache_entry *src = NULL, *dest = NULL;
 	int ret;
 	struct iovec iov[2];
@@ -943,12 +961,7 @@ static int parse_ip6(struct pkt *p)
 
 static void xlate_6to4_icmp_error(struct pkt *p)
 {
-	struct {
-		struct tun_pi pi;
-		struct ip4 ip4;
-		struct icmp icmp;
-		struct ip4 ip4_em;
-	} header;
+	struct ip4_error header;
 	struct iovec iov[2];
 	struct pkt p_em;
 	uint32_t mtu;

--- a/nat64.c
+++ b/nat64.c
@@ -236,7 +236,7 @@ static void xlate_4to6_data(struct pkt *p)
 		struct tun_pi pi;
 		struct ip6 ip6;
 		struct ip6_frag ip6_frag;
-	} __attribute__ ((__packed__)) header;
+	} header;
 	struct cache_entry *src = NULL, *dest = NULL;
 	struct iovec iov[2];
 	int no_frag_hdr = 0;
@@ -424,7 +424,7 @@ static void xlate_4to6_icmp_error(struct pkt *p)
 		struct ip6 ip6;
 		struct icmp icmp;
 		struct ip6 ip6_em;
-	} __attribute__ ((__packed__)) header;
+	} header;
 	struct iovec iov[2];
 	struct pkt p_em;
 	uint32_t mtu;
@@ -637,7 +637,7 @@ static void host_send_icmp6(uint8_t tc, struct in6_addr *src,
 		struct tun_pi pi;
 		struct ip6 ip6;
 		struct icmp icmp;
-	} __attribute__ ((__packed__)) header;
+	} header;
 	struct iovec iov[2];
 
 	TUN_SET_PROTO(&header.pi,  ETH_P_IPV6);
@@ -802,7 +802,7 @@ static void xlate_6to4_data(struct pkt *p)
 	struct {
 		struct tun_pi pi;
 		struct ip4 ip4;
-	} __attribute__ ((__packed__)) header;
+	} header;
 	struct cache_entry *src = NULL, *dest = NULL;
 	int ret;
 	struct iovec iov[2];
@@ -948,7 +948,7 @@ static void xlate_6to4_icmp_error(struct pkt *p)
 		struct ip4 ip4;
 		struct icmp icmp;
 		struct ip4 ip4_em;
-	} __attribute__ ((__packed__)) header;
+	} header;
 	struct iovec iov[2];
 	struct pkt p_em;
 	uint32_t mtu;

--- a/tayga.h
+++ b/tayga.h
@@ -202,7 +202,7 @@ struct map4 {
 	struct in_addr mask;
 	int prefix_len;
 	int type;
-	struct list_head list;
+	struct list_head list; /* gcfg->map4_list */
 };
 
 /// Mapping entry (IPv6)
@@ -211,7 +211,7 @@ struct map6 {
 	struct in6_addr mask;
 	int prefix_len;
 	int type;
-	struct list_head list;
+	struct list_head list; /* gcfg->map6_list */
 };
 
 /// Mapping entry (Static Maps)
@@ -221,10 +221,11 @@ struct map_static {
 	int conffile_lineno;
 };
 
+/// Free addresses
 struct free_addr {
 	uint32_t addr; /* in-use address (host order) */
 	uint32_t count; /* num of free addresses after addr */
-	struct list_head list;
+	struct list_head list; /* list of struct free_addr */
 };
 
 /// Mapping entry (Dynamic Map)
@@ -233,16 +234,16 @@ struct map_dynamic {
 	struct map6 map6;
 	struct cache_entry *cache_entry;
 	time_t last_use;
-	struct list_head list;
+	struct list_head list; /* referenced by struct dynamic_pool */
 	struct free_addr free;
 };
 
 /// Mapping entry (Dynamic Pool)
 struct dynamic_pool {
 	struct map4 map4;
-	struct list_head mapped_list;
-	struct list_head dormant_list;
-	struct list_head free_list;
+	struct list_head mapped_list;  /* list of struct map_dynamic */
+	struct list_head dormant_list; /* list of struct map_dynamic */
+	struct list_head free_list;    /* list of struct free_addr */
 	struct free_addr free_head;
 };
 
@@ -253,9 +254,9 @@ struct cache_entry {
 	time_t last_use;
 	uint32_t flags;
 	uint16_t ip4_ident;
-	struct list_head list;
-	struct list_head hash4;
-	struct list_head hash6;
+	struct list_head list;  /* gcfg->cache_active or gcfg->cache_pool */
+	struct list_head hash4; /* gcfg->hash_table4 */
+	struct list_head hash6; /* gcfg->hash_table6 */
 };
 
 /// Cache flag bits

--- a/tayga.h
+++ b/tayga.h
@@ -17,6 +17,8 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
+#include <stdalign.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -111,7 +113,10 @@ struct ip4 {
 	uint16_t cksum;
 	struct in_addr src;
 	struct in_addr dest;
-} __attribute__ ((__packed__));
+};
+
+static_assert(alignof(struct ip4) <= 4);
+static_assert(sizeof(struct ip4) == 20);
 
 #define IP4_F_DF	0x4000
 #define IP4_F_MF	0x2000
@@ -124,14 +129,20 @@ struct ip6 {
 	uint8_t hop_limit;
 	struct in6_addr src;
 	struct in6_addr dest;
-} __attribute__ ((__packed__));
+};
+
+static_assert(alignof(struct ip6) <= 4);
+static_assert(sizeof(struct ip6) == 40);
 
 struct ip6_frag {
 	uint8_t next_header;
 	uint8_t reserved;
 	uint16_t offset_flags; /* 15-3: frag offset, 2-0: flags */
 	uint32_t ident;
-} __attribute__ ((__packed__));
+};
+
+static_assert(alignof(struct ip6_frag) <= 4);
+static_assert(sizeof(struct ip6_frag) == 8);
 
 #define IP6_F_MF	0x0001
 #define IP6_F_MASK	0xfff8
@@ -141,7 +152,10 @@ struct icmp {
 	uint8_t code;
 	uint16_t cksum;
 	uint32_t word;
-} __attribute__ ((__packed__));
+};
+
+static_assert(alignof(struct icmp) <= 4);
+static_assert(sizeof(struct icmp) == 8);
 
 #define	WKPF	(htonl(0x0064ff9b))
 
@@ -169,6 +183,10 @@ struct pkt {
 	uint32_t data_len;
 	uint32_t header_len; /* inc IP hdr for v4 but excl IP hdr for v6 */
 };
+
+// Ensure that the data field has enough alignment for ip4 and ip6 structs
+static_assert((offsetof(struct pkt, data) & (alignof(struct ip4) - 1)) == 0);
+static_assert((offsetof(struct pkt, data) & (alignof(struct ip6) - 1)) == 0);
 
 /// Type of mapping in mapping list
 enum {


### PR DESCRIPTION
This PR includes the following changes to the code:

1. Help along #67 by removing `__attribute__((__packed__))`

The `packed` attribute causes a structure's requested alignment to be 1 (ie. no alignment).
For programs that handle network packets, this is often necessary. But for Tayga specifically these are not required because the structures are always allocated at a 4-byte alignment boundary.
This will require future patches to be careful: if the size of `struct tun_pi` is changed for example, this could cause padding issues.
Note: These alignment assertions are made using the C11 `static_assert` macro/keyword.
There are versions of this check which are compatible with C89 if that is required.

The code `tayga.c:286` is the only remaining warning. It could be suppressed by casting the result of the write with `(void)write(...)`, but it may better to have some error handling instead.

2. Consolidate endian checks in `addrmap.c` to a single macro

The code here handles a lot of conversions between network and host endian and was previously written with macro guards in the function bodies, resulting in a lot of duplicate code.
This change adds the macro `BIG_LITTLE(x, y)`, which expands to `(x)` on big endian systems and `(y)` on little endian systems.
I believe this makes the code significantly easier to follow.

3. Additional comments and other forms of documentation

The packet headers in `addrmap.c` were given explicit names, rather than being defined inside the function definition.
I also added comments to all of the intrusive lists' struct fields to document which list the given `struct list_head` belongs to and vice-versa.
The TODO on `create_cache` was expanded a bit as well.

Note: I am not able to test these changes on big endian or 32-bit machines, as I do not have any systems in those architectures. If Tayga is trying to support those systems the changes to struct packing may need different alignment assertions.