### PR TITLE
Fix serialization of dynamic map if `time_t` != `long`

### DIFF
--- a/tayga.h
+++ b/tayga.h
@@ -238,6 +238,8 @@ struct map_dynamic {
 	struct free_addr free;
 };
 
+static_assert(sizeof(time_t) == 8, "64-bit time_t is required");
+
 /// Mapping entry (Dynamic Pool)
 struct dynamic_pool {
 	struct map4 map4;


### PR DESCRIPTION
This fixes a warning on systems with `sizeof(long) = 32` (#67), but also prevents a future bug that could cause mapping entries to be dropped earlier than they should on 32-bit platforms after [2038](https://en.wikipedia.org/wiki/Year_2038_problem).
I added an assertion for 64-bit `time_t`: systems with 32-bit `time_t` will always have issues as Tayga uses [`time`](https://www.cppreference.com/w/c/chrono/time.html) to make comparisons.