### PR TITLE
make: allow CC, CFLAGS and LDFLAGS to be defined by the caller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Default compiler flags
-CC := gcc
-CFLAGS := -Wall -O2
-LDFLAGS := -flto=auto
+CC ?= gcc
+CFLAGS ?= -Wall -O2
+LDFLAGS ?= -flto=auto
 SOURCES := nat64.c addrmap.c dynamic.c tayga.c conffile.c
 
 # Compile Tayga


### PR DESCRIPTION
Ports build systems usually define these for the platform so this makes building easier and avoids build problems with incompatible options.