### PR TITLE
Allow compile-time override of configuration path

### DIFF
--- a/tayga.h
+++ b/tayga.h
@@ -97,7 +97,9 @@ struct tun_pi {
 #define DELIM		" \t\r\n"
 
 /// Default configuration path
+#ifndef TAYGA_CONF_PATH
 #define TAYGA_CONF_PATH "/etc/tayga.conf"
+#endif
 
 
 /* Protocol structures */


### PR DESCRIPTION
Enable setting the path with a compiler flag (since FreeBSD uses /usr/local/etc).