### PR TITLE
Resolve Build w/o LTO

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -21,13 +21,21 @@ jobs:
             with:
               ref: ${{ inputs.ver }}
           - name: run build gcc
-            run: make CC=gcc
+            run: make CC=gcc CFLAGS="-Werror -Wall -O2"
           - name: run test gcc
             run: make test CC=gcc
           - name: run build clang
-            run: make CC=clang
+            run: make CC=clang  FLAGS="-Werror -Wall -O2"
           - name: run test clang
             run: make test CC=clang
+          - name: run build gcc w/o LTO
+            run: make CC=gcc LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+          - name: run test gcc w/o LTO
+            run: make test CC=gcc LDFLAGS=""
+          - name: run build clang w/o LTO
+            run: make CC=clang LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+          - name: run test clang w/o LTO
+            run: make test CC=clang LDFLAGS=""
     test-arm64:
         runs-on: ubuntu-24.04-arm 
         steps:
@@ -42,3 +50,11 @@ jobs:
             run: make CC=clang CFLAGS="-Werror -Wall -O2"
           - name: run test clang
             run: make test CC=clang
+          - name: run build gcc w/o LTO
+            run: make CC=gcc LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+          - name: run test gcc w/o LTO
+            run: make test CC=gcc LDFLAGS=""
+          - name: run build clang w/o LTO
+            run: make CC=clang LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+          - name: run test clang w/o LTO
+            run: make test CC=clang LDFLAGS=""

--- a/addrmap.c
+++ b/addrmap.c
@@ -26,8 +26,6 @@
 # error Unsupported byte order
 #endif
 
-extern time_t now;
-
 /**
  * @brief Check if an IPv4 address is valid
  * 

--- a/addrmap.c
+++ b/addrmap.c
@@ -492,7 +492,7 @@ int append_to_prefix(struct in6_addr *addr6, const struct in_addr *addr4,
 int map_ip4_to_ip6(struct in6_addr *addr6, const struct in_addr *addr4,
 		struct cache_entry **c_ptr)
 {
-	uint32_t hash;
+	uint32_t hash = 0;
 	int ret;
 	struct list_head *entry;
 	struct cache_entry *c;
@@ -623,7 +623,7 @@ static int extract_from_prefix(struct in_addr *addr4,
 int map_ip6_to_ip4(struct in_addr *addr4, const struct in6_addr *addr6,
 		struct cache_entry **c_ptr, int dyn_alloc)
 {
-	uint32_t hash;
+	uint32_t hash = 0;
 	int ret = 0;
 	struct list_head *entry;
 	struct cache_entry *c;

--- a/dynamic.c
+++ b/dynamic.c
@@ -23,9 +23,6 @@
 #define MAP_FILE	"dynamic.map"
 #define TMP_MAP_FILE	"dynamic.map~~"
 
-extern struct config *gcfg;
-extern time_t now;
-
 static struct map_dynamic *alloc_map_dynamic(const struct in6_addr *addr6,
 		const struct in_addr *addr4, struct free_addr *f)
 {

--- a/nat64.c
+++ b/nat64.c
@@ -56,8 +56,6 @@ struct ip4_error {
     struct ip4 ip4_em;
 };
 
-extern struct config *gcfg;
-
 /**
  * @brief Print an IPv4 packet to the log
  *

--- a/tayga.h
+++ b/tayga.h
@@ -356,6 +356,7 @@ enum {
 
 /* TAYGA function prototypes */
 extern struct config *gcfg;
+extern time_t now;
 
 /* addrmap.c */
 int validate_ip4_addr(const struct in_addr *a);

--- a/test/unit.c
+++ b/test/unit.c
@@ -18,7 +18,11 @@
 #include <stdio.h>
 #include <setjmp.h>
 #include <string.h>
+#include <time.h>
  
+/* Global vars */
+time_t now;
+
 /* Overall test status (1 on failure, 0 on pass) */
 int test_stat = 0;
 int print_fail_only = 0;

--- a/test/unit_conffile.c
+++ b/test/unit_conffile.c
@@ -25,6 +25,15 @@ static struct config tcfg;
 static char *tmap4[100] = {0};
 static char *tmap6[100] = {0};
 
+/* assign_dynamic 
+ * required for addrmap.c to link
+ * we need addrmap.c for this test
+ * but do not need dyanmic
+ */
+struct map6 *assign_dynamic(const struct in6_addr *addr6) {
+    return NULL;
+}
+
 
 /* Function to simulate getenv 
  * set getenv_case to a nonzero number to change the return


### PR DESCRIPTION
When building without LTO and with strict error checking (-Werror), there are build warnings which become errors. 

The test suite is built with -Werror, so this also causes the test to fail on distros which do not enable LTO. 