### PR TITLE
Various fixes to packaging workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean:
 # If systemd is detected, copy systemd service file
 # If systemd is detected and conf does not already exist, copy example conf file
 .PHONY: install install-live
-install: $(TARGET)
+install:
 	-mkdir -p $(DESTDIR)$(sbindir) $(DESTDIR)$(mandir)/man5 $(DESTDIR)$(mandir)/man8
 	$(INSTALL_PROGRAM) tayga $(DESTDIR)$(sbindir)/tayga
 	$(INSTALL_DATA) tayga.8 $(DESTDIR)$(mandir)/man8


### PR DESCRIPTION
During a package build in an isolated unprivileged build environment, `setcap(8)` will likely not be available or have no permission to set the file caps.
The file caps are specified out-of-band to be applied at installation time by the package installer, like `dpkg` or `rpm`, and in some systems are controlled by a different privilege management tool. So in that kind of environment it makes no sense to call `setcap(8)` from `make install`, and the program has no permission so that fails the entire `make install` invocation early.

Also, some smaller fixes.