### PR TITLE
Use matrix jobs in CI/CD to not duplicate code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[.github/workflows/{*.yaml,*.yml}]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -17,33 +17,38 @@ permissions: { }
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    test:
-        permissions:
-          contents: read
-        runs-on: ${{ matrix.os }}
-        strategy:
-          fail-fast: false
-          matrix:
-            os:
-              - ubuntu-24.04
-              - ubuntu-24.04-arm
-        steps:
-          - uses: actions/checkout@v4
-            with:
-              ref: ${{ inputs.ver || github.ref }}
-          - name: run build gcc
-            run: make CC=gcc CFLAGS="-Werror -Wall -O2"
-          - name: run test gcc
-            run: make test CC=gcc
-          - name: run build clang
-            run: make CC=clang CFLAGS="-Werror -Wall -O2"
-          - name: run test clang
-            run: make test CC=clang
-          - name: run build gcc w/o LTO
-            run: make CC=gcc LDFLAGS="" CFLAGS="-Werror -Wall -O2"
-          - name: run test gcc w/o LTO
-            run: make test CC=gcc LDFLAGS=""
-          - name: run build clang w/o LTO
-            run: make CC=clang LDFLAGS="" CFLAGS="-Werror -Wall -O2"
-          - name: run test clang w/o LTO
-            run: make test CC=clang LDFLAGS=""
+  test:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ver || github.ref }}
+      - name: run build gcc
+        run: make CC=gcc CFLAGS="-Werror -Wall -O2"
+      - name: run test gcc
+        run: make test CC=gcc
+      - name: run build clang
+        run: make CC=clang CFLAGS="-Werror -Wall -O2"
+      - name: run test clang
+        run: make test CC=clang
+      - name: run build gcc w/o LTO
+        run: make CC=gcc LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+      - name: run test gcc w/o LTO
+        run: make test CC=gcc LDFLAGS=""
+      - name: run build clang w/o LTO
+        run: make CC=clang LDFLAGS="" CFLAGS="-Werror -Wall -O2"
+      - name: run test clang w/o LTO
+        run: make test CC=clang LDFLAGS=""

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,40 +8,29 @@ on:
   workflow_dispatch:
     inputs:
       ver:
-        description: 'Branch'
-        default: "main"
+        description: 'Any valid git ref'
+        required: false
         type: string
+
+# permissions are set per job
+permissions: { }
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    test-amd64:
-        runs-on: ubuntu-24.04
+    test:
+        permissions:
+          contents: read
+        runs-on: ${{ matrix.os }}
+        strategy:
+          fail-fast: false
+          matrix:
+            os:
+              - ubuntu-24.04
+              - ubuntu-24.04-arm
         steps:
           - uses: actions/checkout@v4
             with:
-              ref: ${{ inputs.ver }}
-          - name: run build gcc
-            run: make CC=gcc CFLAGS="-Werror -Wall -O2"
-          - name: run test gcc
-            run: make test CC=gcc
-          - name: run build clang
-            run: make CC=clang  FLAGS="-Werror -Wall -O2"
-          - name: run test clang
-            run: make test CC=clang
-          - name: run build gcc w/o LTO
-            run: make CC=gcc LDFLAGS="" CFLAGS="-Werror -Wall -O2"
-          - name: run test gcc w/o LTO
-            run: make test CC=gcc LDFLAGS=""
-          - name: run build clang w/o LTO
-            run: make CC=clang LDFLAGS="" CFLAGS="-Werror -Wall -O2"
-          - name: run test clang w/o LTO
-            run: make test CC=clang LDFLAGS=""
-    test-arm64:
-        runs-on: ubuntu-24.04-arm 
-        steps:
-          - uses: actions/checkout@v4
-            with:
-              ref: ${{ inputs.ver }}
+              ref: ${{ inputs.ver || github.ref }}
           - name: run build gcc
             run: make CC=gcc CFLAGS="-Werror -Wall -O2"
           - name: run test gcc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,42 +10,45 @@ on:
         required: true
         type: string
 
+# permissions are set per job
+permissions: { }
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Create version.h and tag release
   tag-rel:
     permissions:
-        contents: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-            # Fetch all
-            fetch-depth: 0
+          # Fetch all
+          fetch-depth: 0
       - name: Tag release
-        run: |        
-            echo "#define TAYGA_VERSION \"${{ inputs.ver }}\"" > version.h
-            echo "#define TAYGA_BRANCH \"main\"" >> version.h
-            echo "#define TAYGA_COMMIT \"RELEASE\"" >> version.h
-            echo "RELEASE=${{ inputs.ver }}" > release
-            git add -f version.h release
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -m "autogenerate release version file"
-            git tag ${{ inputs.ver }}
-            git push origin ${{ inputs.ver }}
+        run: |
+          echo "#define TAYGA_VERSION \"${{ inputs.ver }}\"" > version.h
+          echo "#define TAYGA_BRANCH \"main\"" >> version.h
+          echo "#define TAYGA_COMMIT \"RELEASE\"" >> version.h
+          echo "RELEASE=${{ inputs.ver }}" > release
+          git add -f version.h release
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "autogenerate release version file"
+          git tag ${{ inputs.ver }}
+          git push origin ${{ inputs.ver }}
   #Build binaries
   build-rel:
     needs: tag-rel
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-        with: 
-            ref: ${{ inputs.ver }}
+        with:
+          ref: ${{ inputs.ver }}
       - uses: jirutka/setup-alpine@v1
         with:
-            branch: v3.19
-            packages: gcc make libc-dev linux-headers
+          branch: v3.19
+          packages: gcc make libc-dev linux-headers
       - name: run build x86-64
         run: make static
         shell: alpine.sh {0}
@@ -54,6 +57,6 @@ jobs:
         shell: alpine.sh {0}
       - uses: actions/upload-artifact@v4
         with:
-            name: build-amd64
-            path: tayga
-            if-no-files-found: error
+          name: build-amd64
+          path: tayga
+          if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,47 +8,44 @@ on:
   workflow_dispatch:
     inputs:
       ver:
-        description: 'Version tag'
-        default: "main"
+        description: 'Any valid git ref'
+        required: false
         type: string
+
+# permissions are set per job
+permissions: { }
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    test:
-        runs-on: ubuntu-latest  
-        steps:
-          - uses: actions/checkout@v4
-            with:
-              ref: ${{ inputs.ver }}
-          - name: run build
-            run: make
-          - name: install deps
-            run: sudo apt-get install -y python3-pyroute2 python3-scapy
-          - name: run test
-            run: make fullsuite
-          - uses: actions/upload-artifact@v4
-            with:
-                name: results-amd64
-                path: |
-                    test/*.rpt
-                    test/*.log
-                if-no-files-found: error
-    test-arm:
-        runs-on: ubuntu-24.04-arm 
-        steps:
-          - uses: actions/checkout@v4
-            with:
-              ref: ${{ inputs.ver }}
-          - name: run build
-            run: make
-          - name: install deps
-            run: sudo apt-get install -y python3-pyroute2 python3-scapy
-          - name: run test
-            run: make fullsuite
-          - uses: actions/upload-artifact@v4
-            with:
-                name: results-arm64
-                path: |
-                    test/*.rpt
-                    test/*.log
-                if-no-files-found: error
+  test:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        include:
+          - arch: amd64
+            os: ubuntu-latest
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ver || github.ref }}
+      - name: run build
+        run: make
+      - name: install deps
+        run: sudo apt-get install -y python3-pyroute2 python3-scapy
+      - name: run test
+        run: make fullsuite
+      - uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.arch }}
+          path: |
+            test/*.rpt
+            test/*.log
+          if-no-files-found: error


### PR DESCRIPTION
- Deduplicated workflows to use matrix jobs.
- Added `.editorconfig` for workflows for unified formatting
- Fixed a typo in the amd64 job where the `run build clang` step used `FLAGS` instead of `CFLAGS`
- The `inputs.ver` is now optional and when empty, it uses the default ref, which is whichever branch or tag the user started the workflow in the GitHub UI
- Refactored the permissions on workflows and made them more strict

I still have some suggestions, but didn't want to force them into this PR, such as
- add a default entry to the `.editorconfig` that applies to all files, but this is subjective, so I'll leave that to you
- Make the basic test and full test suite run on pull request to main.
  - This would ensure automated testing, not having to rely on manual workflow dispatch (human error)
  - However from my testing, the steps never fail (exit non-zero) even when tests are failing. This gives the false impression that all tests are passing, when the logs show many failing tests. A non-zero exit code woul ensure this is discovered in PRs, but I'll leave that to a future PR, not here.