### PR TITLE
Add ExecSearchPath to tayga@.service

### DIFF
--- a/scripts/tayga@.service
+++ b/scripts/tayga@.service
@@ -8,6 +8,9 @@ After=network.target
 # /etc/tayga/instancename.conf
 # systemctl enable tayga@instancename.service
 Type=notify
+
+# Ensure sbin directories are searched for the tayga binary
+ExecSearchPath=/usr/local/sbin:/usr/sbin
 ExecStart=tayga --config /etc/tayga/%i.conf --journal --nodetach
 
 # Hardening options


### PR DESCRIPTION
I found a bug while doing a test for [the discussion post on v0.9.6](https://github.com/apalrd/tayga/discussions/142). Adding this ExecSearchPath line made it work on my machine. On Arch Linux, `systemd-path search-binaries-default` returns only '/usr/local/bin:/usr/bin', but I have no idea about other machines.