### PR TITLE
fix broken ICMP checksum on big-endian machines

### DIFF
--- a/nat64.c
+++ b/nat64.c
@@ -127,6 +127,11 @@ static void log_pkt6(int err, struct pkt *p, const char *msg)
 		type, saddr, daddr, (p->header_len + p->data_len),p->data_proto,msg);
 }
 
+static uint16_t checksum_extend_byte(uint8_t b)
+{
+	return htons(b << 8);
+}
+
 static uint16_t ip_checksum(void *d, uint32_t c)
 {
 	uint32_t sum = 0xffff;
@@ -138,7 +143,7 @@ static uint16_t ip_checksum(void *d, uint32_t c)
 	}
 
 	if (c)
-		sum += htons(*((uint8_t *)p) << 8);
+		sum += checksum_extend_byte(*((uint8_t *)p));
 
 	while (sum > 0xffff)
 		sum = (sum & 0xffff) + (sum >> 16);
@@ -294,10 +299,12 @@ static int xlate_payload_4to6(struct pkt *p, struct ip6 *ip6, int em)
 		cksum = ones_add(p->icmp->cksum, cksum);
 		if (p->icmp->type == 8) {
 			p->icmp->type = 128;
-			p->icmp->cksum = ones_add(cksum, ~(128 - 8));
+			p->icmp->cksum = ones_add(cksum,
+						~checksum_extend_byte(128 - 8));
 		} else {
 			p->icmp->type = 129;
-			p->icmp->cksum = ones_add(cksum, ~(129 - 0));
+			p->icmp->cksum = ones_add(cksum,
+						~checksum_extend_byte(129 - 0));
 		}
 		return ERROR_NONE;
 	/* UDP */
@@ -889,10 +896,12 @@ static int xlate_payload_6to4(struct pkt *p, struct ip4 *ip4, int em)
 		cksum = ones_add(p->icmp->cksum, cksum);
 		if (p->icmp->type == 128) {
 			p->icmp->type = 8;
-			p->icmp->cksum = ones_add(cksum, 128 - 8);
+			p->icmp->cksum = ones_add(cksum,
+						checksum_extend_byte(128 - 8));
 		} else {
 			p->icmp->type = 0;
-			p->icmp->cksum = ones_add(cksum, 129 - 0);
+			p->icmp->cksum = ones_add(cksum,
+						checksum_extend_byte(129 - 0));
 		}
 		return ERROR_NONE;
 	/* UDP */


### PR DESCRIPTION
This patches fixes wrong ICMP checksum of translated packets on big-endian machines

The patch is authored by upstream author Nathan Lutchansky <lutchann@litech.org>
Source of the patch: http://forum.mikrotik.com/viewtopic.php?f=15&t=82329

The patch was maintained downstream in OpenWrt since 2014.
https://github.com/openwrt/packages/commit/8a90bbadd7e11444713da51827a93600e8355f1b

@oskar456
@lutchann

