### PR TITLE
Refactor command line parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC ?= gcc
 CFLAGS ?= -Wall -O2
 LDFLAGS ?= -flto=auto
 LDLIBS := -lpthread
-SOURCES := nat64.c addrmap.c dynamic.c tayga.c conffile.c log.c tun.c
+SOURCES := nat64.c addrmap.c dynamic.c tayga.c conffile.c log.c tun.c cmdline.c
 
 #Default installation paths (may be overridden by environment variables)
 prefix ?= /usr/local

--- a/addrmap.c
+++ b/addrmap.c
@@ -195,24 +195,24 @@ int calc_ip6_mask(struct in6_addr *mask, const struct in6_addr *addr, int len)
 static uint32_t hash_ip4(const struct in_addr *addr4)
 {
 	return ((uint32_t)(addr4->s_addr *
-				gcfg->rand[0])) >> (32 - gcfg->hash_bits);
+				gcfg.rand[0])) >> (32 - gcfg.hash_bits);
 }
 
 static uint32_t hash_ip6(const struct in6_addr *addr6)
 {
 	uint32_t h;
-	h = addr6->s6_addr32[0] + gcfg->rand[0];
-	h ^= addr6->s6_addr32[1] + gcfg->rand[1];
-	h ^= addr6->s6_addr32[2] + gcfg->rand[2];
-	h ^= addr6->s6_addr32[3] + gcfg->rand[3];
-	return h >> (32 - gcfg->hash_bits);
+	h = addr6->s6_addr32[0] + gcfg.rand[0];
+	h ^= addr6->s6_addr32[1] + gcfg.rand[1];
+	h ^= addr6->s6_addr32[2] + gcfg.rand[2];
+	h ^= addr6->s6_addr32[3] + gcfg.rand[3];
+	return h >> (32 - gcfg.hash_bits);
 }
 
 static void add_to_hash_table(struct cache_entry *c, uint32_t hash4,
 		uint32_t hash6)
 {
-	list_add(&c->hash4, &gcfg->hash_table4[hash4]);
-	list_add(&c->hash6, &gcfg->hash_table6[hash6]);
+	list_add(&c->hash4, &gcfg.hash_table4[hash4]);
+	list_add(&c->hash6, &gcfg.hash_table6[hash6]);
 }
 
 /**
@@ -221,55 +221,55 @@ static void add_to_hash_table(struct cache_entry *c, uint32_t hash4,
  * This function initializes the two hash sets used
  * for caching address translations.
  * If it has not been done already, this function allocates
- * `gcfg->cache_size` cache entries for the memory pool.
+ * `gcfg.cache_size` cache entries for the memory pool.
  *
  * The address translation state is a set of IPv4-IPv6 address pairs.
  * There is additional metada as well: see `struct cache_entry`.
- * These pairs are stored in the linked list `gcfg->list`.
- * The cache is two hash sets (`gcfg->hash_table4` and `gcfg->hash_table6`)
+ * These pairs are stored in the linked list `gcfg.list`.
+ * The cache is two hash sets (`gcfg.hash_table4` and `gcfg.hash_table6`)
  * that let Tayga query elements of this set using the IPv4
  * or the IPv6 address.
  * These hash sets use separate-chaining with a fixed bucket size
- * (configurable as `gcfg->cache_size`),
+ * (configurable as `gcfg.cache_size`),
  * so the code here must initialize each of the buckets.
  *
  */
 void create_cache(void)
 {
-	int i, hash_size = 1 << gcfg->hash_bits;
+	int i, hash_size = 1 << gcfg.hash_bits;
 	struct list_head *entry;
 	struct cache_entry *c;
 
-	if (gcfg->hash_table4) {
-		free(gcfg->hash_table4);
-		free(gcfg->hash_table6);
+	if (gcfg.hash_table4) {
+		free(gcfg.hash_table4);
+		free(gcfg.hash_table6);
 	}
 
-	gcfg->hash_table4 = (struct list_head *)
+	gcfg.hash_table4 = (struct list_head *)
 				malloc(hash_size * sizeof(struct list_head));
-	gcfg->hash_table6 = (struct list_head *)
+	gcfg.hash_table6 = (struct list_head *)
 				malloc(hash_size * sizeof(struct list_head));
-	if (!gcfg->hash_table4 || !gcfg->hash_table6) {
+	if (!gcfg.hash_table4 || !gcfg.hash_table6) {
 		slog(LOG_CRIT, "Unable to allocate %d bytes for hash table\n",
 				hash_size * sizeof(struct list_head));
 		exit(1);
 	}
 	for (i = 0; i < hash_size; ++i) {
-		list_init(&gcfg->hash_table4[i]);
-		list_init(&gcfg->hash_table6[i]);
+		list_init(&gcfg.hash_table4[i]);
+		list_init(&gcfg.hash_table6[i]);
 	}
 
-	if (list_empty(&gcfg->cache_pool) && list_empty(&gcfg->cache_active)) {
-		c = calloc(gcfg->cache_size, sizeof(struct cache_entry));
-		for (i = 0; i < gcfg->cache_size; ++i) {
+	if (list_empty(&gcfg.cache_pool) && list_empty(&gcfg.cache_active)) {
+		c = calloc(gcfg.cache_size, sizeof(struct cache_entry));
+		for (i = 0; i < gcfg.cache_size; ++i) {
 			list_init(&c->list);
 			list_init(&c->hash4);
 			list_init(&c->hash6);
-			list_add_tail(&c->list, &gcfg->cache_pool);
+			list_add_tail(&c->list, &gcfg.cache_pool);
 			++c;
 		}
 	} else {
-		list_for_each(entry, &gcfg->cache_active) {
+		list_for_each(entry, &gcfg.cache_active) {
 			c = list_entry(entry, struct cache_entry, list);
 			list_init(&c->hash4);
 			list_init(&c->hash6);
@@ -286,15 +286,15 @@ static struct cache_entry *cache_insert(const struct in_addr *addr4,
 {
 	struct cache_entry *c;
 
-	if (list_empty(&gcfg->cache_pool))
+	if (list_empty(&gcfg.cache_pool))
 		return NULL;
-	c = list_entry(gcfg->cache_pool.next, struct cache_entry, list);
+	c = list_entry(gcfg.cache_pool.next, struct cache_entry, list);
 	c->addr4 = *addr4;
 	c->addr6 = *addr6;
 	c->last_use = now;
 	c->flags = 0;
 	c->ip4_ident = 1;
-	list_add(&c->list, &gcfg->cache_active);
+	list_add(&c->list, &gcfg.cache_active);
 	add_to_hash_table(c, hash4, hash6);
 	return c;
 }
@@ -309,7 +309,7 @@ struct map4 *find_map4(const struct in_addr *addr4)
 	struct list_head *entry;
 	struct map4 *m;
 
-	list_for_each(entry, &gcfg->map4_list) {
+	list_for_each(entry, &gcfg.map4_list) {
 		m = list_entry(entry, struct map4, list);
 		if (m->addr.s_addr == (m->mask.s_addr & addr4->s_addr))
 			return m;
@@ -327,7 +327,7 @@ struct map6 *find_map6(const struct in6_addr *addr6)
 	struct list_head *entry;
 	struct map6 *m;
 
-	list_for_each(entry, &gcfg->map6_list) {
+	list_for_each(entry, &gcfg.map6_list) {
 		m = list_entry(entry, struct map6, list);
 		if (IN6_IS_IN_NET(addr6, &m->addr, &m->mask))
 			return m;
@@ -347,7 +347,7 @@ int insert_map4(struct map4 *m, struct map4 **conflict)
 	struct list_head *entry;
 	struct map4 *s;
 
-	list_for_each(entry, &gcfg->map4_list) {
+	list_for_each(entry, &gcfg.map4_list) {
 		s = list_entry(entry, struct map4, list);
 		if (s->prefix_len < m->prefix_len)
 			break;
@@ -374,7 +374,7 @@ int insert_map6(struct map6 *m, struct map6 **conflict)
 	struct list_head *entry, *insert_pos = NULL;
 	struct map6 *s;
 
-	list_for_each(entry, &gcfg->map6_list) {
+	list_for_each(entry, &gcfg.map6_list) {
 		s = list_entry(entry, struct map6, list);
 		if (s->prefix_len < m->prefix_len) {
 			if (IN6_IS_IN_NET(&m->addr, &s->addr, &s->mask))
@@ -386,7 +386,7 @@ int insert_map6(struct map6 *m, struct map6 **conflict)
 				goto conflict;
 		}
 	}
-	list_add_tail(&m->list, insert_pos ? insert_pos : &gcfg->map6_list);
+	list_add_tail(&m->list, insert_pos ? insert_pos : &gcfg.map6_list);
 	return 0;
 
 conflict:
@@ -461,7 +461,7 @@ int append_to_prefix(struct in6_addr *addr6, const struct in_addr *addr4,
 		if (prefix->s6_addr32[0] == WKPF &&
 			!prefix->s6_addr32[1] &&
 			!prefix->s6_addr32[2] &&
-			gcfg->wkpf_strict &&
+			gcfg.wkpf_strict &&
 			is_private_ip4_addr(addr4))
 			return ERROR_REJECT;
 		addr6->s6_addr32[0] = prefix->s6_addr32[0];
@@ -492,28 +492,28 @@ int map_ip4_to_ip6(struct in6_addr *addr6, const struct in_addr *addr4)
 	struct map_static *s;
 	struct map_dynamic *d = NULL;
 
-	if (gcfg->cache_size) {
+	if (gcfg.cache_size) {
 		hash = hash_ip4(addr4);
 
-		pthread_mutex_lock(&gcfg->cache_mutex);
-		list_for_each(entry, &gcfg->hash_table4[hash]) {
+		pthread_mutex_lock(&gcfg.cache_mutex);
+		list_for_each(entry, &gcfg.hash_table4[hash]) {
 			c = list_entry(entry, struct cache_entry, hash4);
 			if (addr4->s_addr == c->addr4.s_addr) {
 				*addr6 = c->addr6;
 				c->last_use = now;
-				pthread_mutex_unlock(&gcfg->cache_mutex);
+				pthread_mutex_unlock(&gcfg.cache_mutex);
 				return 0;
 			}
 		}
-		pthread_mutex_unlock(&gcfg->cache_mutex);
+		pthread_mutex_unlock(&gcfg.cache_mutex);
 	}
 
 
-	pthread_mutex_lock(&gcfg->map_mutex);
+	pthread_mutex_lock(&gcfg.map_mutex);
 	map4 = find_map4(addr4);
 
 	if (!map4) {
-		pthread_mutex_unlock(&gcfg->map_mutex);
+		pthread_mutex_unlock(&gcfg.map_mutex);
 		return ERROR_REJECT;
 	}
 
@@ -529,13 +529,13 @@ int map_ip4_to_ip6(struct in6_addr *addr6, const struct in_addr *addr4)
 		s = container_of(map4, struct map_static, map4);
 		ret = append_to_prefix(addr6, addr4, &s->map6.addr,s->map6.prefix_len);
 		if (ret < 0) {
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ret;
 		}
 		break;
 	case MAP_TYPE_DYNAMIC_POOL:
 		slog(LOG_DEBUG,"%s:%d Address map is dynamic pool\n",__FUNCTION__,__LINE__);
-		pthread_mutex_unlock(&gcfg->map_mutex);
+		pthread_mutex_unlock(&gcfg.map_mutex);
 		return ERROR_REJECT;
 	case MAP_TYPE_DYNAMIC_HOST:
 		d = container_of(map4, struct map_dynamic, map4);
@@ -544,13 +544,13 @@ int map_ip4_to_ip6(struct in6_addr *addr6, const struct in_addr *addr4)
 		break;
 	default:
 		slog(LOG_DEBUG,"%s:%d Hit default case\n",__FUNCTION__,__LINE__);
-		pthread_mutex_unlock(&gcfg->map_mutex);
+		pthread_mutex_unlock(&gcfg.map_mutex);
 		return ERROR_DROP;
 	}
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 
-	if (gcfg->cache_size) {		
-		pthread_mutex_lock(&gcfg->cache_mutex);
+	if (gcfg.cache_size) {
+		pthread_mutex_lock(&gcfg.cache_mutex);
 		c = cache_insert(addr4, addr6, hash, hash_ip6(addr6));
 
 		/* Alloc Dynamic */
@@ -559,7 +559,7 @@ int map_ip4_to_ip6(struct in6_addr *addr6, const struct in_addr *addr4)
 			if (c)
 				c->flags |= CACHE_F_REP_AGEOUT;
 		}
-		pthread_mutex_unlock(&gcfg->cache_mutex);
+		pthread_mutex_unlock(&gcfg.cache_mutex);
 	}
 
 	return ERROR_NONE;
@@ -632,29 +632,29 @@ int map_ip6_to_ip4(struct in_addr *addr4, const struct in6_addr *addr6, int dyn_
 	struct map_static *s;
 	struct map_dynamic *d = NULL;
 
-	if (gcfg->cache_size) {
+	if (gcfg.cache_size) {
 		hash = hash_ip6(addr6);
 
-		pthread_mutex_lock(&gcfg->cache_mutex);
-		list_for_each(entry, &gcfg->hash_table6[hash]) {
+		pthread_mutex_lock(&gcfg.cache_mutex);
+		list_for_each(entry, &gcfg.hash_table6[hash]) {
 			c = list_entry(entry, struct cache_entry, hash6);
 			if (IN6_ARE_ADDR_EQUAL(addr6, &c->addr6)) {
 				*addr4 = c->addr4;
 				c->last_use = now;
-				pthread_mutex_unlock(&gcfg->cache_mutex);
+				pthread_mutex_unlock(&gcfg.cache_mutex);
 				return 0;
 			}
 		}
-		pthread_mutex_unlock(&gcfg->cache_mutex);
+		pthread_mutex_unlock(&gcfg.cache_mutex);
 	}
-	pthread_mutex_lock(&gcfg->map_mutex);
+	pthread_mutex_lock(&gcfg.map_mutex);
 	map6 = find_map6(addr6);
 
 	if (!map6) {
 		if (dyn_alloc)
 			map6 = assign_dynamic(addr6);
 		if (!map6) {
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT; //TODO what's the right behavior here
 		}
 	}
@@ -673,21 +673,21 @@ int map_ip6_to_ip4(struct in_addr *addr4, const struct in6_addr *addr6, int dyn_
 	case MAP_TYPE_RFC6052:
 		ret = extract_from_prefix(addr4, addr6, map6->prefix_len);
 		if (ret < 0) {
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_DROP;
 		}
 		if (map6->addr.s6_addr32[0] == WKPF &&
 			map6->addr.s6_addr32[1] == 0 &&
 			map6->addr.s6_addr32[2] == 0 &&
-			gcfg->wkpf_strict &&
+			gcfg.wkpf_strict &&
 				is_private_ip4_addr(addr4)) {
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 		s = container_of(map6, struct map_static, map6);
 		if (find_map4(addr4) != &s->map4){
 			slog(LOG_DEBUG,"%s:%d Dropping packet due to hairpin condition",__FUNCTION__,__LINE__);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_DROP;
 		}
 		break;
@@ -698,13 +698,13 @@ int map_ip6_to_ip4(struct in_addr *addr4, const struct in6_addr *addr6, int dyn_
 		break;
 	default:
 		slog(LOG_DEBUG,"%s:%d Dropping packet due to default case",__FUNCTION__,__LINE__);
-		pthread_mutex_unlock(&gcfg->map_mutex);
+		pthread_mutex_unlock(&gcfg.map_mutex);
 		return ERROR_DROP;
 	}
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 
-	if (gcfg->cache_size) {
-		pthread_mutex_lock(&gcfg->cache_mutex);
+	if (gcfg.cache_size) {
+		pthread_mutex_lock(&gcfg.cache_mutex);
 		c = cache_insert(addr4, addr6, hash_ip4(addr4), hash);
 
 		/* Is Dynamic */
@@ -713,7 +713,7 @@ int map_ip6_to_ip4(struct in_addr *addr4, const struct in6_addr *addr6, int dyn_
 			if (c)
 				c->flags |= CACHE_F_REP_AGEOUT;
 		}
-		pthread_mutex_unlock(&gcfg->cache_mutex);
+		pthread_mutex_unlock(&gcfg.cache_mutex);
 	}
 
 	return ERROR_NONE;
@@ -744,21 +744,21 @@ void addrmap_maint(void)
 	/* report_ageout will need map mutex
 	 * and we must acquire map before cache if both are required 
 	 * to avoid any deadlock */
-    pthread_mutex_lock(&gcfg->map_mutex);
-	pthread_mutex_lock(&gcfg->cache_mutex);
+    pthread_mutex_lock(&gcfg.map_mutex);
+	pthread_mutex_lock(&gcfg.cache_mutex);
 
-	list_for_each_safe(entry, next, &gcfg->cache_active) {
+	list_for_each_safe(entry, next, &gcfg.cache_active) {
 		c = list_entry(entry, struct cache_entry, list);
 		if (c->last_use + CACHE_MAX_AGE < now) {
 			if (c->flags & CACHE_F_REP_AGEOUT)
 				report_ageout(c);
-			list_add(&c->list, &gcfg->cache_pool);
+			list_add(&c->list, &gcfg.cache_pool);
 			list_del(&c->hash4);
 			list_del(&c->hash6);
 		}
 	}
-	pthread_mutex_unlock(&gcfg->cache_mutex);
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.cache_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 }
 
 
@@ -772,16 +772,16 @@ static void cache_evict_map4(const struct map4 *m4)
     struct list_head *entry, *next;
     struct cache_entry *c;
 
-    pthread_mutex_lock(&gcfg->cache_mutex);
-    list_for_each_safe(entry, next, &gcfg->cache_active) {
+    pthread_mutex_lock(&gcfg.cache_mutex);
+    list_for_each_safe(entry, next, &gcfg.cache_active) {
         c = list_entry(entry, struct cache_entry, list);
         if (m4->addr.s_addr == (m4->mask.s_addr & c->addr4.s_addr)) {
             list_del(&c->hash4);
             list_del(&c->hash6);
-            list_add(&c->list, &gcfg->cache_pool);
+            list_add(&c->list, &gcfg.cache_pool);
         }
     }
-    pthread_mutex_unlock(&gcfg->cache_mutex);
+    pthread_mutex_unlock(&gcfg.cache_mutex);
 }
 
 /**
@@ -794,16 +794,16 @@ static void cache_evict_map6(const struct map6 *m6)
     struct list_head *entry, *next;
     struct cache_entry *c;
 
-    pthread_mutex_lock(&gcfg->cache_mutex);
-    list_for_each_safe(entry, next, &gcfg->cache_active) {
+    pthread_mutex_lock(&gcfg.cache_mutex);
+    list_for_each_safe(entry, next, &gcfg.cache_active) {
         c = list_entry(entry, struct cache_entry, list);
 		if (IN6_IS_IN_NET(&c->addr6, &m6->addr, &m6->mask)){
             list_del(&c->hash4);
             list_del(&c->hash6);
-            list_add(&c->list, &gcfg->cache_pool);
+            list_add(&c->list, &gcfg.cache_pool);
         }
     }
-    pthread_mutex_unlock(&gcfg->cache_mutex);
+    pthread_mutex_unlock(&gcfg.cache_mutex);
 }
 
 /**
@@ -949,7 +949,7 @@ static int addrmap_entry(int ln, char **args)
 	}
 
 	/* Lock map to insert into v4/v6 */
-	pthread_mutex_lock(&gcfg->map_mutex);
+	pthread_mutex_lock(&gcfg.map_mutex);
 
 	/*
 	 * Attempt to insert both sides.  insert_map4/6 returns -1 and sets
@@ -982,7 +982,7 @@ static int addrmap_entry(int ln, char **args)
 			     "map entry found for mapping on line %d "
 			     "(m4 type %d, m6 type %d)\n", ln, m4->type, m6->type);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 
@@ -995,7 +995,7 @@ static int addrmap_entry(int ln, char **args)
 			slog(LOG_ERR, "MAP-FILE: Existing fixed map entry found with non-writable"
 				" origin on line %d (m4 orgin %d, m6 origin %d)\n", ln, n1->origin, n2->origin);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		} else if (n1 == n2) {
 			/*
@@ -1030,7 +1030,7 @@ static int addrmap_entry(int ln, char **args)
 			/* Remove the IPv6 half we just inserted */
 			list_del(&m->map6.list);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 		/* Get parent static map entry */
@@ -1043,7 +1043,7 @@ static int addrmap_entry(int ln, char **args)
 			/* Remove the IPv6 half we just inserted */
 			list_del(&m->map6.list);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 		addrmap_delete4(m4);
@@ -1061,7 +1061,7 @@ static int addrmap_entry(int ln, char **args)
 			/* Remove the IPv4 half we just inserted */
 			list_del(&m->map4.list);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 		/* Get parent static map entry */
@@ -1074,7 +1074,7 @@ static int addrmap_entry(int ln, char **args)
 			/* Remove the IPv4 half we just inserted */
 			list_del(&m->map4.list);
 			free(m);
-			pthread_mutex_unlock(&gcfg->map_mutex);
+			pthread_mutex_unlock(&gcfg.map_mutex);
 			return ERROR_REJECT;
 		}
 		addrmap_delete6(m6);
@@ -1085,7 +1085,7 @@ static int addrmap_entry(int ln, char **args)
 	}
 
 	/* Finished without error */
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 	return ERROR_NONE;
 }
 
@@ -1117,22 +1117,22 @@ int addrmap_reload(void)
 	char *c, *tokptr;
 
 	/* Skip reloading if no file is configured */
-	if (!gcfg->map_file[0]) {
+	if (!gcfg.map_file[0]) {
 		return ERROR_NONE;
 	}
-	slog(LOG_DEBUG,"MAP-FILE: loading file %s\n",gcfg->map_file);
+	slog(LOG_DEBUG,"MAP-FILE: loading file %s\n",gcfg.map_file);
 
 	/* Step 1 - open file and check for file-access errors */
-	in = fopen(gcfg->map_file, "r");
+	in = fopen(gcfg.map_file, "r");
 	if (!in) {
 		slog(LOG_ERR, "MAP-FILE: Unable to open %s: %s\n",
-		     gcfg->map_file, strerror(errno));
+		     gcfg.map_file, strerror(errno));
 		return ERROR_REJECT;
 	}
 
 	/* Step 2 - mark existing entries in the map list */
-	pthread_mutex_lock(&gcfg->map_mutex);
-	list_for_each(entry, &gcfg->map4_list) {
+	pthread_mutex_lock(&gcfg.map_mutex);
+	list_for_each(entry, &gcfg.map4_list) {
 		m4 = list_entry(entry, struct map4, list);
 		if (m4->type == MAP_TYPE_STATIC) {
 			s = container_of(m4, struct map_static, map4);
@@ -1141,7 +1141,7 @@ int addrmap_reload(void)
 			}
 		}
 	}
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 
 	/* Step 3 - parse the file */
 	while (fgets(line, sizeof(line), in)) {
@@ -1149,7 +1149,7 @@ int addrmap_reload(void)
 
 		if (strlen(line) + 1 == sizeof(line)) {
 			slog(LOG_ERR, "MAP-FILE: Line %d of %s is too long\n",
-			     ln, gcfg->map_file);
+			     ln, gcfg.map_file);
 			continue;
 		}
 
@@ -1162,7 +1162,7 @@ int addrmap_reload(void)
 				break;
 			if (arg_count == MAX_ARGS) {
 				slog(LOG_ERR, "MAP-FILE: Too many tokens on line "
-				     "%d of %s\n", ln, gcfg->map_file);
+				     "%d of %s\n", ln, gcfg.map_file);
 				break;
 			}
 			args[arg_count++] = c;
@@ -1175,7 +1175,7 @@ int addrmap_reload(void)
 		/* The only valid directive in the map file is "map" */
 		if (strcasecmp(args[0], "map") != 0) {
 			slog(LOG_ERR, "MAP-FILE: Unknown directive \"%s\" on "
-			     "line %d of %s\n", args[0], ln, gcfg->map_file);
+			     "line %d of %s\n", args[0], ln, gcfg.map_file);
 			continue;
 		}
 
@@ -1184,7 +1184,7 @@ int addrmap_reload(void)
 		if (arg_count != 2) {
 			slog(LOG_ERR, "MAP-FILE: \"map\" directive requires "
 			     "exactly 2 arguments on line %d of %s\n",
-			     ln, gcfg->map_file);
+			     ln, gcfg.map_file);
 			continue;
 		}
 
@@ -1194,8 +1194,8 @@ int addrmap_reload(void)
 	fclose(in);
 
 	/* Step 4 - delete entries not reloaded */
-	pthread_mutex_lock(&gcfg->map_mutex);
-	list_for_each_safe(entry, next, &gcfg->map4_list) {
+	pthread_mutex_lock(&gcfg.map_mutex);
+	list_for_each_safe(entry, next, &gcfg.map4_list) {
 		m4 = list_entry(entry, struct map4, list);
 		if (m4->type == MAP_TYPE_STATIC) {
 			s = container_of(m4, struct map_static, map4);
@@ -1204,7 +1204,7 @@ int addrmap_reload(void)
 			}
 		}
 	}
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 	/* Only file access errors are returned as errors */
 	return ERROR_NONE;
 }

--- a/addrmap.c
+++ b/addrmap.c
@@ -255,24 +255,24 @@ void create_cache(void)
 		exit(1);
 	}
 	for (i = 0; i < hash_size; ++i) {
-		INIT_LIST_HEAD(&gcfg->hash_table4[i]);
-		INIT_LIST_HEAD(&gcfg->hash_table6[i]);
+		list_init(&gcfg->hash_table4[i]);
+		list_init(&gcfg->hash_table6[i]);
 	}
 
 	if (list_empty(&gcfg->cache_pool) && list_empty(&gcfg->cache_active)) {
 		c = calloc(gcfg->cache_size, sizeof(struct cache_entry));
 		for (i = 0; i < gcfg->cache_size; ++i) {
-			INIT_LIST_HEAD(&c->list);
-			INIT_LIST_HEAD(&c->hash4);
-			INIT_LIST_HEAD(&c->hash6);
+			list_init(&c->list);
+			list_init(&c->hash4);
+			list_init(&c->hash6);
 			list_add_tail(&c->list, &gcfg->cache_pool);
 			++c;
 		}
 	} else {
 		list_for_each(entry, &gcfg->cache_active) {
 			c = list_entry(entry, struct cache_entry, list);
-			INIT_LIST_HEAD(&c->hash4);
-			INIT_LIST_HEAD(&c->hash6);
+			list_init(&c->hash4);
+			list_init(&c->hash6);
 			add_to_hash_table(c, hash_ip4(&c->addr4),
 						hash_ip6(&c->addr6));
 		}
@@ -875,11 +875,11 @@ static int addrmap_entry(int ln, char **args)
 	m->map4.type = MAP_TYPE_STATIC;
 	m->map4.prefix_len = 32;
 	calc_ip4_mask(&m->map4.mask, NULL, 32);
-	INIT_LIST_HEAD(&m->map4.list);
+	list_init(&m->map4.list);
 	m->map6.type = MAP_TYPE_STATIC;
 	m->map6.prefix_len = 128;
 	calc_ip6_mask(&m->map6.mask, NULL, 128);
-	INIT_LIST_HEAD(&m->map6.list);
+	list_init(&m->map6.list);
 	m->line_no = ln;
 	m->origin = MAP_ORIGIN_MAPFILE;
 

--- a/cmdline.c
+++ b/cmdline.c
@@ -84,9 +84,12 @@ void cmdline_parse(int argc, char **argv) {
 	};
 
 	/* Arg parsing loop */
-	for (int c; c = getopt_long(argc, argv, "c:dhnu:g:rp:", long_opts, NULL), c != -1;) {
+	for (int c; c = getopt_long(argc, argv, "-c:dhnu:g:rp:", long_opts, NULL), c != -1;) {
 		switch (c) {
 		case 0:
+			break;
+		case 1:
+			fprintf(stderr, "Warning: skipping positional argument `%s`\n", optarg);
 			break;
 		case 'c':
 			arg_conffile = optarg;

--- a/cmdline.c
+++ b/cmdline.c
@@ -139,5 +139,5 @@ void cmdline_parse(int argc, char **argv) {
 	}
 
 	if (arg_log_out != -1)
-		gcfg->log_out = arg_log_out;
+		gcfg.log_out = arg_log_out;
 }

--- a/cmdline.c
+++ b/cmdline.c
@@ -1,0 +1,140 @@
+#include "cmdline.h"
+#include "tayga.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <getopt.h>
+
+static const char *progname;
+
+char *arg_conffile = TAYGA_CONF_PATH;
+char *arg_user = NULL;
+char *arg_group = NULL;
+char *arg_pidfile = NULL;
+int arg_do_mktun = 0;
+int arg_do_rmtun = 0;
+int arg_do_chroot = 0;
+int arg_detach = 1;
+
+static void usage(int code) {
+	int pad = strlen(progname);
+	fprintf(stderr,
+			"TAYGA version %s\n"
+			"Usage:\n"
+			"%s [-c|--config CONFIGFILE] [-d|--debug] [-n|--nodetach]\n"
+			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n"
+			"%*c [--syslog|--stdout|--journal]\n"
+			"%s --mktun [-c|--config CONFIGFILE]\n"
+			"%s --rmtun [-c|--config CONFIGFILE]\n"
+			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n\n"
+			"--config FILE      : Read configuration options from FILE\n"
+			"--debug, -d        : Enable debug messages (implies --nodetach and --stdout)\n"
+			"--nodetach         : Do not fork the process\n"
+			"--syslog           : Log messages to syslog (default)\n"
+			"--stdout           : Log messages to stdout\n"
+			"--journal          : Log messages to the systemd journal\n"
+			"--user USERID      : Set uid to USERID after initialization\n"
+			"--group GROUPID    : Set gid to GROUPID after initialization\n"
+			"--chroot           : chroot() to data-dir (specified in config file)\n"
+			"--pidfile FILE     : Write process ID of daemon to FILE\n"
+			"--mktun            : Create the persistent TUN interface\n"
+			"--rmtun            : Remove the persistent TUN interface\n"
+			"--help, -h         : Show this help message\n",
+		TAYGA_VERSION,
+		progname,
+		pad, ' ',
+		pad, ' ',
+		progname,
+		progname,
+		pad, ' '
+	);
+	exit(code);
+}
+
+/* Used during argument parsing, before logging is setup */
+static void die(const char *format, ...) {
+	va_list ap;
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	putc('\n', stderr);
+	exit(1);
+}
+
+void cmdline_parse(int argc, char **argv) {
+	progname = argv[0];
+
+	int arg_log_out = -1;
+	struct option long_opts[] = {
+		{ "mktun", no_argument, &arg_do_mktun, 1 },
+		{ "rmtun", no_argument, &arg_do_rmtun, 1 },
+		{ "syslog", no_argument, &arg_log_out, LOG_TO_SYSLOG },
+		{ "stdout", no_argument, &arg_log_out, LOG_TO_STDOUT },
+		{ "journal", no_argument, &arg_log_out, LOG_TO_JOURNAL },
+		{ "help", no_argument, NULL, 'h' },
+		{ "config", required_argument, NULL, 'c' },
+		{ "nodetach", no_argument, NULL, 'n' },
+		{ "user", required_argument, NULL, 'u' },
+		{ "group", required_argument, NULL, 'g' },
+		{ "chroot", no_argument, NULL, 'r' },
+		{ "pidfile", required_argument, NULL, 'p' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	/* Arg parsing loop */
+	for (int c; c = getopt_long(argc, argv, "c:dhnu:g:rp:", long_opts, NULL), c != -1;) {
+		switch (c) {
+		case 0:
+			break;
+		case 'c':
+			arg_conffile = optarg;
+			break;
+		case 'd':
+			arg_log_out = LOG_TO_STDOUT;
+			arg_detach = 0;
+			break;
+		case 'n':
+			arg_detach = 0;
+			break;
+		case 'u':
+			arg_user = optarg;
+			break;
+		case 'g':
+			arg_group = optarg;
+			break;
+		case 'r':
+			arg_do_chroot = 1;
+			break;
+		case 'p':
+			arg_pidfile = optarg;
+			break;
+		case 'h':
+			usage(0);
+			break;
+		default:
+			die("Try `%s --help' for more information", progname);
+		}
+	}
+
+	// Make sure --mktun/--rmtun is not combined with unsupported options.
+	if (arg_do_mktun || arg_do_rmtun) {
+		if (arg_do_mktun && arg_do_rmtun)
+			die("Error: both --mktun and --rmtun specified");
+		if (arg_user)
+			die("Error: cannot specify -u or --user with mktun/rmtun operation");
+		if (arg_group)
+			die("Error: cannot specify -g or --group with mktun/rmtun operation");
+		if (arg_do_chroot)
+			die("Error: cannot specify -r or --chroot with mktun/rmtun operation");
+
+		// Cannot error here as it would be a nasty breaking change.
+		if (arg_log_out != -1)
+			fprintf(stderr, "Warning: cannot set logging on mktun/rmtun operation, forcing stdout\n");
+		arg_log_out = LOG_TO_STDOUT;
+	}
+
+	if (arg_log_out != -1)
+		gcfg->log_out = arg_log_out;
+}

--- a/cmdline.h
+++ b/cmdline.h
@@ -1,0 +1,16 @@
+#ifndef __TAYGA_CMDLINE_H__
+#define __TAYGA_CMDLINE_H__
+
+
+extern char *arg_conffile;
+extern char *arg_user;
+extern char *arg_group;
+extern char *arg_pidfile;
+extern int arg_do_mktun;
+extern int arg_do_rmtun;
+extern int arg_do_chroot;
+extern int arg_detach;
+
+void cmdline_parse(int argc, char **argv);
+
+#endif

--- a/conffile.c
+++ b/conffile.c
@@ -620,6 +620,7 @@ static int config_log(int ln, int arg_count, char **args)
 		else if(!strcasecmp(args[i],"icmp")) gcfg.log_opts |= LOG_OPT_ICMP;
 		else if(!strcasecmp(args[i],"self")) gcfg.log_opts |= LOG_OPT_SELF;
 		else if(!strcasecmp(args[i],"dyn")) gcfg.log_opts |= LOG_OPT_DYN;
+		else if (!strcasecmp(args[i],"all")) gcfg.log_opts |= LOG_OPT_ALL;
 		else {
 			slog(LOG_CRIT, "Error: invalid value for log on line %d\n",ln);
 			return ERROR_REJECT;

--- a/conffile.c
+++ b/conffile.c
@@ -55,11 +55,11 @@ static struct map_static *alloc_map_static(int ln)
 	m->map4.type = MAP_TYPE_STATIC;
 	m->map4.prefix_len = 32;
 	calc_ip4_mask(&m->map4.mask, NULL, 32);
-	INIT_LIST_HEAD(&m->map4.list);
+	list_init(&m->map4.list);
 	m->map6.type = MAP_TYPE_STATIC;
 	m->map6.prefix_len = 128;
 	calc_ip6_mask(&m->map6.mask, NULL, 128);
-	INIT_LIST_HEAD(&m->map6.list);
+	list_init(&m->map6.list);
 	m->line_no = ln;
 	m->origin = MAP_ORIGIN_CONFFILE;
 	return m;
@@ -332,7 +332,7 @@ static int config_tun_ip(int ln, int arg_count, char **args)
 			return ERROR_REJECT;
 		}
 		ip6->prefix_len = prefix;
-		INIT_LIST_HEAD(&ip6->list);
+		list_init(&ip6->list);
 		list_add(&ip6->list,&gcfg->tun_ip6_list);
 		return ERROR_NONE;
 	}
@@ -347,7 +347,7 @@ static int config_tun_ip(int ln, int arg_count, char **args)
 			return ERROR_REJECT;
 		}
 		ip4->prefix_len = prefix;
-		INIT_LIST_HEAD(&ip4->list);
+		list_init(&ip4->list);
 		list_add(&ip4->list,&gcfg->tun_ip4_list);
 		return ERROR_NONE;
 	}
@@ -396,7 +396,7 @@ static int config_tun_route(int ln, int arg_count, char **args)
 			return ERROR_REJECT;
 		}
 		ip6->prefix_len = prefix;
-		INIT_LIST_HEAD(&ip6->list);
+		list_init(&ip6->list);
 		list_add(&ip6->list,&gcfg->tun_rt6_list);
 		return ERROR_NONE;
 	}
@@ -411,7 +411,7 @@ static int config_tun_route(int ln, int arg_count, char **args)
 			return ERROR_REJECT;
 		}
 		ip4->prefix_len = prefix;
-		INIT_LIST_HEAD(&ip4->list);
+		list_init(&ip4->list);
 		list_add(&ip4->list,&gcfg->tun_rt4_list);
 		return ERROR_NONE;
 	}
@@ -517,13 +517,13 @@ static int config_dynamic_pool(int ln, int arg_count, char **args)
 		return ERROR_REJECT;
 	}
 	memset(pool, 0, sizeof(struct dynamic_pool));
-	INIT_LIST_HEAD(&pool->mapped_list);
-	INIT_LIST_HEAD(&pool->dormant_list);
-	INIT_LIST_HEAD(&pool->free_list);
+	list_init(&pool->mapped_list);
+	list_init(&pool->dormant_list);
+	list_init(&pool->free_list);
 
 	m4 = &pool->map4;
 	m4->type = MAP_TYPE_DYNAMIC_POOL;
-	INIT_LIST_HEAD(&m4->list);
+	list_init(&m4->list);
 
 	if (parse_prefix(AF_INET, args[0], &m4->addr, &m4->prefix_len) ||
 			calc_ip4_mask(&m4->mask, &m4->addr, m4->prefix_len)) {
@@ -553,7 +553,7 @@ static int config_dynamic_pool(int ln, int arg_count, char **args)
 
 	pool->free_head.addr = ntohl(m4->addr.s_addr);
 	pool->free_head.count = (1 << (32 - m4->prefix_len)) - 1;
-	INIT_LIST_HEAD(&pool->free_head.list);
+	list_init(&pool->free_head.list);
 	list_add(&pool->free_head.list, &pool->free_list);
 
 	gcfg->dynamic_pool = pool;
@@ -739,22 +739,22 @@ int config_init(void)
 		slog(LOG_CRIT, "Unable to allocate config memory\n");
 		return ERROR_REJECT;
 	}
-	INIT_LIST_HEAD(&gcfg->map4_list);
-	INIT_LIST_HEAD(&gcfg->map6_list);
+	list_init(&gcfg->map4_list);
+	list_init(&gcfg->map6_list);
 	gcfg->dyn_min_lease = 7200 + 4 * 60; /* just over two hours */
 	gcfg->dyn_max_lease = 14 * 86400;
 	gcfg->max_commit_delay = gcfg->dyn_max_lease / 4;
 	gcfg->hash_bits = 7;
 	gcfg->cache_size = 8192;
-	INIT_LIST_HEAD(&gcfg->cache_pool);
-	INIT_LIST_HEAD(&gcfg->cache_active);
+	list_init(&gcfg->cache_pool);
+	list_init(&gcfg->cache_active);
 	gcfg->wkpf_strict = 1;
 	gcfg->udp_cksum_mode = UDP_CKSUM_DROP;
 	gcfg->workers = -1;
-	INIT_LIST_HEAD(&gcfg->tun_ip4_list);
-	INIT_LIST_HEAD(&gcfg->tun_ip6_list);
-	INIT_LIST_HEAD(&gcfg->tun_rt4_list);
-	INIT_LIST_HEAD(&gcfg->tun_rt6_list);
+	list_init(&gcfg->tun_ip4_list);
+	list_init(&gcfg->tun_ip6_list);
+	list_init(&gcfg->tun_rt4_list);
+	list_init(&gcfg->tun_rt6_list);
 	gcfg->tun_up = 0;
 	return ERROR_NONE;
 }

--- a/conffile.c
+++ b/conffile.c
@@ -18,7 +18,7 @@
 
 #include "tayga.h"
 
-struct config *gcfg;
+struct config gcfg;
 
 static int parse_prefix(int af, char *src, void *prefix, int *prefix_len)
 {
@@ -116,17 +116,17 @@ static int config_ipv4_addr(int ln, int arg_count, char **args)
 	//arg_count unused
 	(void)arg_count;
 
-	if (gcfg->local_addr4.s_addr) {
+	if (gcfg.local_addr4.s_addr) {
 		slog(LOG_CRIT, "Error: duplicate ipv4-addr directive on "
 				"line %d\n", ln);
 		return ERROR_REJECT;
 	}
-	if (!inet_pton(AF_INET, args[0], &gcfg->local_addr4)) {
+	if (!inet_pton(AF_INET, args[0], &gcfg.local_addr4)) {
 		slog(LOG_CRIT, "Expected an IPv4 address but found \"%s\" on "
 				"line %d\n", args[0], ln);
 		return ERROR_REJECT;
 	}
-	int ret = validate_ip4_addr(&gcfg->local_addr4);
+	int ret = validate_ip4_addr(&gcfg.local_addr4);
 	if (ret == ERROR_LOCAL) {
 		slog(LOG_WARNING, "Using link local address %s in ipv4-addr "
 			"directive, use with caution\n", args[0]);
@@ -143,17 +143,17 @@ static int config_ipv6_addr(int ln, int arg_count, char **args)
 	//arg_count unused
 	(void)arg_count;
 
-	if (gcfg->local_addr6.s6_addr[0]) {
+	if (gcfg.local_addr6.s6_addr[0]) {
 		slog(LOG_CRIT, "Error: duplicate ipv6-addr directive on line "
 				"%d\n", ln);
 		return ERROR_REJECT;
 	}
-	if (!inet_pton(AF_INET6, args[0], &gcfg->local_addr6)) {
+	if (!inet_pton(AF_INET6, args[0], &gcfg.local_addr6)) {
 		slog(LOG_CRIT, "Expected an IPv6 address but found \"%s\" on "
 				"line %d\n", args[0], ln);
 		return ERROR_REJECT;
 	}
-	if (validate_ip6_addr(&gcfg->local_addr6) < 0) {
+	if (validate_ip6_addr(&gcfg.local_addr6) < 0) {
 		slog(LOG_CRIT, "Cannot use reserved address %s in ipv6-addr "
 				"directive, aborting...\n", args[0]);
 		return ERROR_REJECT;
@@ -216,12 +216,12 @@ static int config_wkpf_strict(int ln, int arg_count, char **args)
 	    !strcasecmp(args[0], "on") ||
 	    !strcasecmp(args[0], "yes") ||
 		!strcasecmp(args[0], "1")) {
-		gcfg->wkpf_strict = 1;
+		gcfg.wkpf_strict = 1;
 	} else if (!strcasecmp(args[0], "false") ||
 			   !strcasecmp(args[0], "off") ||
 			   !strcasecmp(args[0], "no") ||
 			   !strcasecmp(args[0], "0")) {
-		gcfg->wkpf_strict = 0;
+		gcfg.wkpf_strict = 0;
 	} else {
 		slog(LOG_CRIT, "Error: invalid value for wkpf-strict on line %d\n",ln);
 		return ERROR_REJECT;
@@ -236,13 +236,13 @@ static int config_udp_cksum_mode(int ln, int arg_count, char **args)
 
 	/* Drop, or some variant of that */
 	if (!strncasecmp(args[0], "dr",2)){
-		gcfg->udp_cksum_mode = UDP_CKSUM_DROP;
+		gcfg.udp_cksum_mode = UDP_CKSUM_DROP;
 	/* Calculate, or some variant of that */
 	} else if (!strncasecmp(args[0], "calc",4)) {
-		gcfg->udp_cksum_mode = UDP_CKSUM_CALC;
+		gcfg.udp_cksum_mode = UDP_CKSUM_CALC;
 	} else if(!strncasecmp(args[0],"forw",4) ||
 		      !strncasecmp(args[0],"fwd",3)) {
-		gcfg->udp_cksum_mode = UDP_CKSUM_FWD;
+		gcfg.udp_cksum_mode = UDP_CKSUM_FWD;
 	} else {
 		slog(LOG_CRIT, "Error: invalid value for udp-cksum-mode on line %d\n",ln);
 		return ERROR_REJECT;
@@ -259,12 +259,12 @@ static int config_tun_up(int ln, int arg_count, char **args)
 	    !strcasecmp(args[0], "on") ||
 	    !strcasecmp(args[0], "yes") ||
 		!strcasecmp(args[0], "1")) {
-		gcfg->tun_up = 1;
+		gcfg.tun_up = 1;
 	} else if (!strcasecmp(args[0], "false") ||
 			   !strcasecmp(args[0], "off") ||
 			   !strcasecmp(args[0], "no") ||
 			   !strcasecmp(args[0], "0")) {
-		gcfg->tun_up = 0;
+		gcfg.tun_up = 0;
 	} else {
 		slog(LOG_CRIT, "Error: invalid value for tun-up on line %d\n",ln);
 		return ERROR_REJECT;
@@ -278,17 +278,17 @@ static int config_tun_device(int ln, int arg_count, char **args)
 	//arg_count unused
 	(void)arg_count;
 
-	if (gcfg->tundev[0]) {
+	if (gcfg.tundev[0]) {
 		slog(LOG_CRIT, "Error: duplicate tun-device directive on line "
 				"%d\n", ln);
 		return ERROR_REJECT;
 	}
-	if (strlen(args[0]) + 1 > sizeof(gcfg->tundev)) {
+	if (strlen(args[0]) + 1 > sizeof(gcfg.tundev)) {
 		slog(LOG_CRIT, "Device name \"%s\" is invalid on line %d\n",
 				args[0], ln);
 		return ERROR_REJECT;
 	}
-	strcpy(gcfg->tundev, args[0]);
+	strcpy(gcfg.tundev, args[0]);
 	return ERROR_NONE;
 }
 
@@ -333,7 +333,7 @@ static int config_tun_ip(int ln, int arg_count, char **args)
 		}
 		ip6->prefix_len = prefix;
 		list_init(&ip6->list);
-		list_add(&ip6->list,&gcfg->tun_ip6_list);
+		list_add(&ip6->list,&gcfg.tun_ip6_list);
 		return ERROR_NONE;
 	}
 	//Then try as IPv4
@@ -348,7 +348,7 @@ static int config_tun_ip(int ln, int arg_count, char **args)
 		}
 		ip4->prefix_len = prefix;
 		list_init(&ip4->list);
-		list_add(&ip4->list,&gcfg->tun_ip4_list);
+		list_add(&ip4->list,&gcfg.tun_ip4_list);
 		return ERROR_NONE;
 	}
 	//Error handling
@@ -397,7 +397,7 @@ static int config_tun_route(int ln, int arg_count, char **args)
 		}
 		ip6->prefix_len = prefix;
 		list_init(&ip6->list);
-		list_add(&ip6->list,&gcfg->tun_rt6_list);
+		list_add(&ip6->list,&gcfg.tun_rt6_list);
 		return ERROR_NONE;
 	}
 	//Then try as IPv4
@@ -412,7 +412,7 @@ static int config_tun_route(int ln, int arg_count, char **args)
 		}
 		ip4->prefix_len = prefix;
 		list_init(&ip4->list);
-		list_add(&ip4->list,&gcfg->tun_rt4_list);
+		list_add(&ip4->list,&gcfg.tun_rt4_list);
 		return ERROR_NONE;
 	}
 	//Error handling
@@ -505,7 +505,7 @@ static int config_dynamic_pool(int ln, int arg_count, char **args)
 	struct dynamic_pool *pool;
 	struct map4 *m4;
 
-	if (gcfg->dynamic_pool) {
+	if (gcfg.dynamic_pool) {
 		slog(LOG_CRIT, "Error: duplicate dynamic-pool directive on "
 				"line %d\n", ln);
 		return ERROR_REJECT;
@@ -556,7 +556,7 @@ static int config_dynamic_pool(int ln, int arg_count, char **args)
 	list_init(&pool->free_head.list);
 	list_add(&pool->free_head.list, &pool->free_list);
 
-	gcfg->dynamic_pool = pool;
+	gcfg.dynamic_pool = pool;
 	return ERROR_NONE;
 }
 
@@ -565,7 +565,7 @@ static int config_data_dir(int ln, int arg_count, char **args)
 	//arg_count unused
 	(void)arg_count;
 
-	if (gcfg->data_dir[0]) {
+	if (gcfg.data_dir[0]) {
 		slog(LOG_CRIT, "Error: duplicate data-dir directive on line "
 				"%d\n", ln);
 		return ERROR_REJECT;
@@ -574,7 +574,7 @@ static int config_data_dir(int ln, int arg_count, char **args)
 		slog(LOG_CRIT, "Error: data-dir must be an absolute path\n");
 		return ERROR_REJECT;
 	}
-	strcpy(gcfg->data_dir, args[0]);
+	strcpy(gcfg.data_dir, args[0]);
 	return ERROR_NONE;
 }
 
@@ -583,12 +583,12 @@ static int config_map_file(int ln, int arg_count, char **args)
 	//arg_count unused
 	(void)arg_count;
 
-	if (gcfg->map_file[0]) {
+	if (gcfg.map_file[0]) {
 		slog(LOG_CRIT, "Error: duplicate map-file directive on line "
 				"%d\n", ln);
 		return ERROR_REJECT;
 	}
-	strcpy(gcfg->map_file, args[0]);
+	strcpy(gcfg.map_file, args[0]);
 	return ERROR_NONE;
 }
 
@@ -604,22 +604,22 @@ static int config_strict_fh(int ln, int arg_count, char **args)
 
 static int config_log(int ln, int arg_count, char **args)
 {
-	if(gcfg->log_opts) {
+	if(gcfg.log_opts) {
 		slog(LOG_CRIT, "Error: duplicate log directive on line "
 				"%d\n", ln);
 		return ERROR_REJECT;
 	}
 	/* Set this flag to detect duplicate entries */
-	gcfg->log_opts |= LOG_OPT_CONFIG;
+	gcfg.log_opts |= LOG_OPT_CONFIG;
 	/* For each arg we have */
 	for(int i = 0; i < arg_count; i++)
 	{
 		/* Check if this arg matches one of these keys, and enable that key */
-		if(!strcasecmp(args[i],"drop")) gcfg->log_opts |= LOG_OPT_DROP;
-		else if(!strcasecmp(args[i],"reject")) gcfg->log_opts |= LOG_OPT_REJECT;
-		else if(!strcasecmp(args[i],"icmp")) gcfg->log_opts |= LOG_OPT_ICMP;
-		else if(!strcasecmp(args[i],"self")) gcfg->log_opts |= LOG_OPT_SELF;
-		else if(!strcasecmp(args[i],"dyn")) gcfg->log_opts |= LOG_OPT_DYN;
+		if(!strcasecmp(args[i],"drop")) gcfg.log_opts |= LOG_OPT_DROP;
+		else if(!strcasecmp(args[i],"reject")) gcfg.log_opts |= LOG_OPT_REJECT;
+		else if(!strcasecmp(args[i],"icmp")) gcfg.log_opts |= LOG_OPT_ICMP;
+		else if(!strcasecmp(args[i],"self")) gcfg.log_opts |= LOG_OPT_SELF;
+		else if(!strcasecmp(args[i],"dyn")) gcfg.log_opts |= LOG_OPT_DYN;
 		else {
 			slog(LOG_CRIT, "Error: invalid value for log on line %d\n",ln);
 			return ERROR_REJECT;
@@ -634,7 +634,7 @@ static int config_offlink_mtu(int ln, int arg_count, char **args)
 	(void)arg_count;
 	
 	/* Offlink MTU already set? */
-	if (gcfg->ipv6_offlink_mtu) {
+	if (gcfg.ipv6_offlink_mtu) {
 		slog(LOG_CRIT, "Error: duplicate offlink-mtu directive on "
 				"line %d\n", ln);
 		return ERROR_REJECT;
@@ -656,7 +656,7 @@ static int config_offlink_mtu(int ln, int arg_count, char **args)
 		return ERROR_REJECT;
 	}
 	/* Set the offlink MTU */
-	gcfg->ipv6_offlink_mtu = mtu;
+	gcfg.ipv6_offlink_mtu = mtu;
 	return ERROR_NONE;
 }
 
@@ -671,7 +671,7 @@ static int config_workers(int ln, int arg_count, char **args)
 	long int workers;
 	
 	/* Offlink MTU already set? */
-	if (gcfg->workers != -1) {
+	if (gcfg.workers != -1) {
 		slog(LOG_CRIT, "Error: duplicate workers directive on "
 				"line %d\n", ln);
 		return ERROR_REJECT;
@@ -692,7 +692,7 @@ static int config_workers(int ln, int arg_count, char **args)
 		return ERROR_REJECT;
 	}
 	/* Set the offlink MTU */
-	gcfg->workers = workers;
+	gcfg.workers = workers;
 	return ERROR_NONE;
 #else
 	//args unused
@@ -731,32 +731,27 @@ struct {
 	{ NULL, NULL, 0 }
 };
 
-int config_init(void)
+void config_init(void)
 {
-	/* Initialize configuration structure to defaults */
-	gcfg = (struct config *) calloc(1, sizeof(struct config));
-	if (!gcfg) {
-		slog(LOG_CRIT, "Unable to allocate config memory\n");
-		return ERROR_REJECT;
-	}
-	list_init(&gcfg->map4_list);
-	list_init(&gcfg->map6_list);
-	gcfg->dyn_min_lease = 7200 + 4 * 60; /* just over two hours */
-	gcfg->dyn_max_lease = 14 * 86400;
-	gcfg->max_commit_delay = gcfg->dyn_max_lease / 4;
-	gcfg->hash_bits = 7;
-	gcfg->cache_size = 8192;
-	list_init(&gcfg->cache_pool);
-	list_init(&gcfg->cache_active);
-	gcfg->wkpf_strict = 1;
-	gcfg->udp_cksum_mode = UDP_CKSUM_DROP;
-	gcfg->workers = -1;
-	list_init(&gcfg->tun_ip4_list);
-	list_init(&gcfg->tun_ip6_list);
-	list_init(&gcfg->tun_rt4_list);
-	list_init(&gcfg->tun_rt6_list);
-	gcfg->tun_up = 0;
-	return ERROR_NONE;
+	gcfg = (struct config){
+		.map4_list = LIST_HEAD(gcfg.map4_list),
+		.map6_list = LIST_HEAD(gcfg.map6_list),
+		.dyn_min_lease = 7200 + 4 * 60, /* just over two hours */
+		.dyn_max_lease = 14 * 86400,
+		.max_commit_delay = (14 * 86400) / 4,
+		.hash_bits = 7,
+		.cache_size = 8192,
+		.cache_pool = LIST_HEAD(gcfg.cache_pool),
+		.cache_active = LIST_HEAD(gcfg.cache_active),
+		.wkpf_strict = 1,
+		.udp_cksum_mode = UDP_CKSUM_DROP,
+		.workers = -1,
+		.tun_ip4_list = LIST_HEAD(gcfg.tun_ip4_list),
+		.tun_ip6_list = LIST_HEAD(gcfg.tun_ip6_list),
+		.tun_rt4_list = LIST_HEAD(gcfg.tun_rt4_list),
+		.tun_rt6_list = LIST_HEAD(gcfg.tun_rt6_list),
+		.tun_up = 0,
+	};
 }
 
 int config_read(char *conffile)
@@ -837,7 +832,7 @@ int config_validate(void)
 	char addrbuf[128];
 
 	/* Now, validate the inputs */
-	if (list_empty(&gcfg->map6_list)) {
+	if (list_empty(&gcfg.map6_list)) {
 		slog(LOG_CRIT, "Error: no translation maps or NAT64 prefix "
 				"configured\n");
 		return ERROR_REJECT;
@@ -848,47 +843,47 @@ int config_validate(void)
 	 * And it can still be overridden by the conf file
 	 */
 	char * sd = getenv("STATE_DIRECTORY");
-	if(sd && !gcfg->data_dir[0]) {
+	if(sd && !gcfg.data_dir[0]) {
 		if (sd[0] != '/') {
 			slog(LOG_CRIT, "Error: STATE_DIRECTORY must be an "
 				"absolute path\n");
 			return ERROR_REJECT;
 		}
 		/* Copy env var into data_dir */
-		if(strlen(sd) + 1 > sizeof(gcfg->data_dir)) {
+		if(strlen(sd) + 1 > sizeof(gcfg.data_dir)) {
 			slog(LOG_CRIT, "Error: STATE_DIRECTORY is too long, "
 					"aborting...\n");
 			return ERROR_REJECT;
 		}
 		/* Copy state directory */
-		strcpy(gcfg->data_dir, sd);
+		strcpy(gcfg.data_dir, sd);
 		/* Check for a : which signifies that we have multiple dirs */
-		for(int i = 0; gcfg->data_dir[i]; i++) {
-			if(gcfg->data_dir[i] == ':') {
+		for(int i = 0; gcfg.data_dir[i]; i++) {
+			if(gcfg.data_dir[i] == ':') {
 				slog(LOG_WARNING, "STATE_DIRECTORY env var contains "
 						"multiple directories, using first one\n");
-				gcfg->data_dir[i] = 0;
+				gcfg.data_dir[i] = 0;
 				break;
 			}
 		}
 	}
 
-	m4 = list_entry(gcfg->map4_list.next, struct map4, list);
-	m6 = list_entry(gcfg->map6_list.next, struct map6, list);
+	m4 = list_entry(gcfg.map4_list.next, struct map4, list);
+	m6 = list_entry(gcfg.map6_list.next, struct map6, list);
 
 	if (m4->type == MAP_TYPE_RFC6052 && m6->type == MAP_TYPE_RFC6052) {
 		slog(LOG_DEBUG,"Disabling cache, not required\n");
-		gcfg->cache_size = 0;
+		gcfg.cache_size = 0;
 	}
 
-	if (!gcfg->local_addr4.s_addr) {
+	if (!gcfg.local_addr4.s_addr) {
 		slog(LOG_CRIT, "Error: no ipv4-addr directive found\n");
 		return ERROR_REJECT;
 	}
 
 	m = alloc_map_static(0);
 	if(!m) return ERROR_REJECT;
-	m->map4.addr = gcfg->local_addr4;
+	m->map4.addr = gcfg.local_addr4;
 	m->origin = MAP_ORIGIN_SELF;
 	if (insert_map4(&m->map4, &m4) < 0) {
 		abort_on_conflict4("Error: ipv4-addr", 0, m4);
@@ -896,18 +891,18 @@ int config_validate(void)
 	}
 
 	/* ipv6-addr is configured and is within the well known prefix */
-	if (gcfg->local_addr6.s6_addr32[0] == WKPF &&
-		gcfg->local_addr6.s6_addr32[1] == 0 &&
-		gcfg->local_addr6.s6_addr32[2] == 0 &&
-		gcfg->wkpf_strict)
+	if (gcfg.local_addr6.s6_addr32[0] == WKPF &&
+		gcfg.local_addr6.s6_addr32[1] == 0 &&
+		gcfg.local_addr6.s6_addr32[2] == 0 &&
+		gcfg.wkpf_strict)
 	{
 		slog(LOG_CRIT, "Error: ipv6-addr directive cannot contain an "
 				"address in the Well-Known Prefix "
 				"(64:ff9b::/96)\n");
 		return ERROR_REJECT;
 	/* ipv6-addr is configured but not within the well known prefix */
-	} else if (gcfg->local_addr6.s6_addr32[0]) {
-		m->map6.addr = gcfg->local_addr6;
+	} else if (gcfg.local_addr6.s6_addr32[0]) {
+		m->map6.addr = gcfg.local_addr6;
 		if (insert_map6(&m->map6, &m6) < 0) {
 			if (m6->type == MAP_TYPE_RFC6052) {
 				inet_ntop(AF_INET6, &m6->addr,
@@ -924,16 +919,16 @@ int config_validate(void)
 		}
 	/* ipv6-addr is zero (not set), generate from ipv4-addr and prefix */
 	} else {
-		m6 = list_entry(gcfg->map6_list.prev, struct map6, list);
+		m6 = list_entry(gcfg.map6_list.prev, struct map6, list);
 		if (m6->type != MAP_TYPE_RFC6052) {
 			slog(LOG_CRIT, "Error: ipv6-addr directive must be "
 					"specified if no NAT64 prefix is "
 					"configured\n");
 			return ERROR_REJECT;
 		}
-		if (append_to_prefix(&gcfg->local_addr6, &gcfg->local_addr4,
+		if (append_to_prefix(&gcfg.local_addr6, &gcfg.local_addr4,
 					&m6->addr, m6->prefix_len)) {
-			if(gcfg->wkpf_strict)
+			if(gcfg.wkpf_strict)
 			{
 				slog(LOG_CRIT, "Error: ipv6-addr directive must be "
 						"specified if prefix is 64:ff9b::/96 "
@@ -942,14 +937,14 @@ int config_validate(void)
 				return ERROR_REJECT;
 			}
 		}
-		m->map6.addr = gcfg->local_addr6;
+		m->map6.addr = gcfg.local_addr6;
 	}
 
 	/* Offlink MTU defaults to 1280 if not set */
-	if (gcfg->ipv6_offlink_mtu <= MTU_MIN) gcfg->ipv6_offlink_mtu = MTU_MIN;
+	if (gcfg.ipv6_offlink_mtu <= MTU_MIN) gcfg.ipv6_offlink_mtu = MTU_MIN;
 
 	/* Tundev must be provided */
-	if(strlen(gcfg->tundev) < 1) {
+	if(strlen(gcfg.tundev) < 1) {
 		slog(LOG_CRIT, "Error: no tun-device directive found\n");
 		return ERROR_REJECT;
 	}

--- a/conffile.c
+++ b/conffile.c
@@ -734,12 +734,11 @@ struct {
 int config_init(void)
 {
 	/* Initialize configuration structure to defaults */
-	gcfg = (struct config *)malloc(sizeof(struct config));
+	gcfg = (struct config *) calloc(1, sizeof(struct config));
 	if (!gcfg) {
 		slog(LOG_CRIT, "Unable to allocate config memory\n");
 		return ERROR_REJECT;
 	}
-	memset(gcfg, 0, sizeof(struct config));
 	INIT_LIST_HEAD(&gcfg->map4_list);
 	INIT_LIST_HEAD(&gcfg->map6_list);
 	gcfg->dyn_min_lease = 7200 + 4 * 60; /* just over two hours */

--- a/docs/man/tayga.conf.5.md
+++ b/docs/man/tayga.conf.5.md
@@ -163,13 +163,15 @@ tayga.conf.
 
     *drop* - Log packets which were dropped.
 
-    *reject* - Log packets which were rejected (ICMP returned)
+    *reject* - Log packets which were rejected (ICMP returned).
 
     *icmp* - Log packets which returned an ICMP for any reason,
     including packets which are part of 'normal' internet traffic (i.e.
-    Packet Too Big or Time Exceeded)
+    Packet Too Big or Time Exceeded).
 
-    *self* - Log packets which were destined for Tayga itself
+    *self* - Log packets which were destined for Tayga itself.
+
+    *all* - Log everything.
 
     No packet logging is enabled by default
 

--- a/dynamic.c
+++ b/dynamic.c
@@ -100,7 +100,7 @@ static void print_dyn_change(char *str, struct map_dynamic *d)
 	inet_ntop(AF_INET, &d->map4.addr, addrbuf4, sizeof(addrbuf4));
 	inet_ntop(AF_INET6, &d->map6.addr, addrbuf6, sizeof(addrbuf6));
 	/* Log dynamic assignment changes */
-	if(gcfg->log_opts & LOG_OPT_DYN) {
+	if(gcfg.log_opts & LOG_OPT_DYN) {
 		slog(LOG_INFO, "DYN: [%s] [%s]->[%s]\n",str,addrbuf4, addrbuf6);
 	}
 }
@@ -115,7 +115,7 @@ struct map6 *assign_dynamic(const struct in6_addr *addr6)
 	struct map4 *m4;
 	struct map_dynamic *d;
 
-	pool = gcfg->dynamic_pool;
+	pool = gcfg.dynamic_pool;
 	if (!pool)
 		return NULL;
 
@@ -156,7 +156,7 @@ struct map6 *assign_dynamic(const struct in6_addr *addr6)
 			if (!d)
 				return NULL;
 			print_dyn_change("assigned", d);
-			gcfg->map_write_pending = 1;
+			gcfg.map_write_pending = 1;
 			goto activate;
 		}
 	}
@@ -167,7 +167,7 @@ struct map6 *assign_dynamic(const struct in6_addr *addr6)
 	d = list_entry(pool->dormant_list.prev, struct map_dynamic, list);
 	d->map6.addr = *addr6;
 	print_dyn_change("reassigned", d);
-	gcfg->map_write_pending = 1;
+	gcfg.map_write_pending = 1;
 
 activate:
 	move_to_mapped(d, pool);
@@ -190,7 +190,7 @@ static void load_map(struct dynamic_pool *pool, const struct in6_addr *addr6,
 		inet_ntop(AF_INET, addr4, addrbuf4, sizeof(addrbuf4));
 		slog(LOG_NOTICE, "Ignoring map for %s from %s/%s that lies "
 				"outside dynamic pool prefix\n", addrbuf4,
-				gcfg->data_dir, MAP_FILE);
+				gcfg.data_dir, MAP_FILE);
 		return;
 	}
 	m4 = find_map4(addr4);
@@ -198,7 +198,7 @@ static void load_map(struct dynamic_pool *pool, const struct in6_addr *addr6,
 		inet_ntop(AF_INET, addr4, addrbuf4, sizeof(addrbuf4));
 		slog(LOG_NOTICE, "Ignoring map for %s from %s/%s that "
 				"conflicts with statically-configured map\n",
-				addrbuf4, gcfg->data_dir, MAP_FILE);
+				addrbuf4, gcfg.data_dir, MAP_FILE);
 		return;
 	}
 	if (validate_ip6_addr(addr6) < 0) {
@@ -206,14 +206,14 @@ static void load_map(struct dynamic_pool *pool, const struct in6_addr *addr6,
 		inet_ntop(AF_INET6, addr6, addrbuf6, sizeof(addrbuf6));
 		slog(LOG_NOTICE, "Ignoring map for %s from %s/%s with "
 				"invalid IPv6 address %s\n", addrbuf4,
-				gcfg->data_dir, MAP_FILE, addrbuf6);
+				gcfg.data_dir, MAP_FILE, addrbuf6);
 		return;
 	}
 	if (find_map6(addr6)) {
 		inet_ntop(AF_INET6, addr6, addrbuf6, sizeof(addrbuf6));
 		slog(LOG_NOTICE, "Ignoring map for %s from %s/%s that "
 				"conflicts with statically-configured map\n",
-				addrbuf6, gcfg->data_dir, MAP_FILE);
+				addrbuf6, gcfg.data_dir, MAP_FILE);
 		return;
 	}
 	addr = ntohl(addr4->s_addr);
@@ -225,7 +225,7 @@ static void load_map(struct dynamic_pool *pool, const struct in6_addr *addr6,
 	if (entry == &pool->free_list || f->addr >= addr) {
 		inet_ntop(AF_INET, addr4, addrbuf4, sizeof(addrbuf4));
 		slog(LOG_NOTICE, "Ignoring duplicate map for %s from %s/%s\n",
-				addrbuf4, gcfg->data_dir, MAP_FILE);
+				addrbuf4, gcfg.data_dir, MAP_FILE);
 		return;
 	}
 	d = alloc_map_dynamic(addr6, addr4, f);
@@ -251,14 +251,14 @@ void load_dynamic(struct dynamic_pool *pool)
 	if (!in) {
 		if (errno != ENOENT)
 			slog(LOG_ERR, "Unable to open %s/%s, ignoring: %s\n",
-					gcfg->data_dir, MAP_FILE,
+					gcfg.data_dir, MAP_FILE,
 					strerror(errno));
 		return;
 	}
 	while (fgets(line, sizeof(line), in)) {
 		if (strlen(line) + 1 == sizeof(line)) {
 			slog(LOG_ERR, "Ignoring oversized line in %s/%s\n",
-					gcfg->data_dir, MAP_FILE);
+					gcfg.data_dir, MAP_FILE);
 			continue;
 		}
 		s4 = strtok_r(line, DELIM, &tokptr);
@@ -289,7 +289,7 @@ void load_dynamic(struct dynamic_pool *pool)
 		continue;
 malformed:
 		slog(LOG_ERR, "Ignoring malformed line in %s/%s\n",
-				gcfg->data_dir, MAP_FILE);
+				gcfg.data_dir, MAP_FILE);
 	}
 	fclose(in);
 
@@ -304,19 +304,19 @@ malformed:
 	}
 	slog(LOG_INFO, "Loaded %d dynamic %s from %s/%s\n", count,
 			count == 1 ? "map" : "maps",
-			gcfg->data_dir, MAP_FILE);
+			gcfg.data_dir, MAP_FILE);
 	if (last_use > now) {
 		slog(LOG_NOTICE, "Note: maps in %s/%s are dated in the future\n",
-				gcfg->data_dir, MAP_FILE);
+				gcfg.data_dir, MAP_FILE);
 		list_for_each(entry, &pool->dormant_list) {
 			d = list_entry(entry, struct map_dynamic, list);
-			d->last_use = now - gcfg->dyn_min_lease;
+			d->last_use = now - gcfg.dyn_min_lease;
 		}
 	} else {
 		while (!list_empty(&pool->dormant_list)) {
 			d = list_entry(pool->dormant_list.next,
 					struct map_dynamic, list);
-			if (d->last_use + gcfg->dyn_min_lease < now)
+			if (d->last_use + gcfg.dyn_min_lease < now)
 				break;
 			move_to_mapped(d, pool);
 		}
@@ -334,7 +334,7 @@ static void write_to_file(struct dynamic_pool *pool)
 	out = fopen(TMP_MAP_FILE, "w");
 	if (!out) {
 		slog(LOG_ERR, "Unable to open %s/%s for writing: %s\n",
-				gcfg->data_dir, TMP_MAP_FILE,
+				gcfg.data_dir, TMP_MAP_FILE,
 				strerror(errno));
 		return;
 	}
@@ -360,8 +360,8 @@ static void write_to_file(struct dynamic_pool *pool)
 	fclose(out);
 	if (rename(TMP_MAP_FILE, MAP_FILE) < 0) {
 		slog(LOG_ERR, "Unable to rename %s/%s to %s/%s: %s\n",
-				gcfg->data_dir, TMP_MAP_FILE,
-				gcfg->data_dir, MAP_FILE,
+				gcfg.data_dir, TMP_MAP_FILE,
+				gcfg.data_dir, MAP_FILE,
 				strerror(errno));
 		unlink(TMP_MAP_FILE);
 	}
@@ -374,13 +374,13 @@ void dynamic_maint(struct dynamic_pool *pool, int shutdown)
 	struct free_addr *f;
 
 	/* Acquire map mutex */
-	pthread_mutex_lock(&gcfg->map_mutex);
+	pthread_mutex_lock(&gcfg.map_mutex);
 
 	list_for_each_safe(entry, next, &pool->mapped_list) {
 		d = list_entry(entry, struct map_dynamic, list);
 		if (d->cache_entry)
 			continue;
-		if (d->last_use + gcfg->dyn_min_lease < now) {
+		if (d->last_use + gcfg.dyn_min_lease < now) {
 			print_dyn_change("dormant", d);
 			move_to_dormant(d, pool);
 		}
@@ -388,7 +388,7 @@ void dynamic_maint(struct dynamic_pool *pool, int shutdown)
 	while (!list_empty(&pool->dormant_list)) {
 		d = list_entry(pool->dormant_list.prev,
 				struct map_dynamic, list);
-		if (d->last_use + gcfg->dyn_max_lease >= now)
+		if (d->last_use + gcfg.dyn_max_lease >= now)
 			break;
 		f = list_entry(d->free.list.prev, struct free_addr, list);
 		f->count += d->free.count + 1;
@@ -398,17 +398,17 @@ void dynamic_maint(struct dynamic_pool *pool, int shutdown)
 	}
 
 	/* Write file if we have a data-dir */
-	if (gcfg->data_dir[0]) {
-		if (shutdown || gcfg->map_write_pending ||
-				gcfg->last_map_write +
-					gcfg->max_commit_delay < now ||
-				gcfg->last_map_write > now) {
+	if (gcfg.data_dir[0]) {
+		if (shutdown || gcfg.map_write_pending ||
+				gcfg.last_map_write +
+					gcfg.max_commit_delay < now ||
+				gcfg.last_map_write > now) {
 			write_to_file(pool);
-			gcfg->last_map_write = now;
-			gcfg->map_write_pending = 0;
+			gcfg.last_map_write = now;
+			gcfg.map_write_pending = 0;
 		}
 	}
 
 	/* Release map mutex when done */
-	pthread_mutex_unlock(&gcfg->map_mutex);
+	pthread_mutex_unlock(&gcfg.map_mutex);
 }

--- a/dynamic.c
+++ b/dynamic.c
@@ -35,24 +35,24 @@ static struct map_dynamic *alloc_map_dynamic(const struct in6_addr *addr6,
 		return NULL;
 	}
 	memset(d, 0, sizeof(struct map_dynamic));
-	INIT_LIST_HEAD(&d->list);
+	list_init(&d->list);
 
 	d->map4.type = MAP_TYPE_DYNAMIC_HOST;
 	d->map4.addr = *addr4;
 	d->map4.prefix_len = 32;
 	calc_ip4_mask(&d->map4.mask, NULL, 32);
-	INIT_LIST_HEAD(&d->map4.list);
+	list_init(&d->map4.list);
 
 	d->map6.type = MAP_TYPE_DYNAMIC_HOST;
 	d->map6.addr = *addr6;
 	d->map6.prefix_len = 128;
 	calc_ip6_mask(&d->map6.mask, NULL, 128);
-	INIT_LIST_HEAD(&d->map6.list);
+	list_init(&d->map6.list);
 
 	d->free.addr = a;
 	d->free.count = f->count - (a - f->addr);
 	f->count = a - f->addr - 1;
-	INIT_LIST_HEAD(&d->free.list);
+	list_init(&d->free.list);
 	list_add(&d->free.list, &f->list);
 
 	return d;

--- a/list.h
+++ b/list.h
@@ -14,7 +14,7 @@ struct list_head {
 #define LIST_HEAD(x) struct list_head x = { &x, &x }
 
 /* Initialize an empty list (required for all malloc'd list_heads) */
-static inline void INIT_LIST_HEAD(struct list_head *x)
+static inline void list_init(struct list_head *x)
 {
 	x->next = x;
 	x->prev = x;

--- a/list.h
+++ b/list.h
@@ -11,7 +11,7 @@ struct list_head {
 };
 
 /* Declare an empty list */
-#define LIST_HEAD(x) struct list_head x = { &x, &x }
+#define LIST_HEAD(x) (struct list_head){ .next = &(x), .prev = &(x) }
 
 /* Initialize an empty list (required for all malloc'd list_heads) */
 static inline void list_init(struct list_head *x)

--- a/log.c
+++ b/log.c
@@ -22,7 +22,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <signal.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -34,31 +33,6 @@
 #include <syslog.h>
 #include <time.h>
 #include <unistd.h>
-
-
-/* Log the message to the configured logger */
-void slog_impl(int priority, const char *file, const char *line, const char *func, const char *format, ...)
-{
-	va_list ap;
-	(void)file;
-	(void)line;
-	(void)func;
-
-	va_start(ap, format);
-	switch (gcfg.log_out) {
-        default:
-		case LOG_TO_STDOUT:
-			vprintf(format, ap);
-			break;
-		case LOG_TO_SYSLOG:
-			vsyslog(priority, format, ap);
-			break;
-		case LOG_TO_JOURNAL:
-			journal_printv_with_location(priority, file, line, func, format, ap);
-			break;
-	}
-	va_end(ap);
-}
 
 
 union sockaddr_union {
@@ -148,7 +122,7 @@ static int journal_fd = -1;
 static const char *syslog_identifier = NULL;
 
 /* Open the systemd journal. Not threadsafe. */
-int journal_init(const char *ident) {
+static int journal_init(const char *ident) {
     if (journal_fd >= 0)
         return 0;
 
@@ -170,7 +144,7 @@ int journal_init(const char *ident) {
 }
 
 /* Close the systemd journal. Not threadsafe. */
-void journal_cleanup(void) {
+static void journal_cleanup(void) {
     close(journal_fd);
     journal_fd = -1;
 }
@@ -184,7 +158,7 @@ void journal_cleanup(void) {
  *   format =~ ^[^\n]+\n?$
  *   vsnprintf(NULL, 0, format, ap) < MESSAGE_SIZE
  */
-int journal_printv_with_location(
+static int journal_printv_with_location(
         int priority, const char *file, const char *line, const char *func,
         const char *format, va_list ap)
 {
@@ -258,4 +232,57 @@ int journal_printv_with_location(
     if (r >= 0)
         return 0;
     return -errno;
+}
+
+/* Log the message to the configured logger */
+void slog_impl(int priority, const char *file, const char *line, const char *func, const char *format, ...)
+{
+	va_list ap;
+	(void)file;
+	(void)line;
+	(void)func;
+
+	va_start(ap, format);
+	switch (gcfg.log_out) {
+        default:
+		case LOG_TO_STDOUT:
+			vprintf(format, ap);
+			break;
+		case LOG_TO_SYSLOG:
+			vsyslog(priority, format, ap);
+			break;
+		case LOG_TO_JOURNAL:
+			journal_printv_with_location(priority, file, line, func, format, ap);
+			break;
+	}
+	va_end(ap);
+}
+
+int log_notify_ready(void) {
+    if(gcfg.log_out == LOG_TO_JOURNAL) {
+		return notify("READY=1");
+	}
+
+    return 0;
+}
+
+/* Setup logging
+ * This must be done before config parsing, since those rely
+ * on logging based on log_out */
+int log_init(void) {
+	if (gcfg.log_out == LOG_TO_SYSLOG) {
+		openlog("tayga", LOG_PID | LOG_NDELAY, LOG_DAEMON);
+	} else if (gcfg.log_out == LOG_TO_JOURNAL) {
+		return journal_init("tayga");
+	}
+
+    return 0;
+}
+
+void log_cleanup(void) {
+    if (gcfg.log_out == LOG_TO_SYSLOG) {
+        closelog();
+    } else if (gcfg.log_out == LOG_TO_JOURNAL) {
+        journal_cleanup();
+    }
 }

--- a/log.c
+++ b/log.c
@@ -45,7 +45,7 @@ void slog_impl(int priority, const char *file, const char *line, const char *fun
 	(void)func;
 
 	va_start(ap, format);
-	switch (gcfg->log_out) {
+	switch (gcfg.log_out) {
         default:
 		case LOG_TO_STDOUT:
 			vprintf(format, ap);

--- a/log.c
+++ b/log.c
@@ -16,6 +16,7 @@
  *  GNU General Public License for more details.
  */
 
+#define SYSLOG_NAMES
 
 #include "tayga.h"
 
@@ -234,6 +235,18 @@ static int journal_printv_with_location(
     return -errno;
 }
 
+/* Get a syslog priority's name */
+static const char *get_priority_name(int priority) {
+    priority = LOG_PRI(priority);
+
+    CODE *code = prioritynames;
+    while (code->c_name && code->c_val != priority)
+        code++;
+    const char *name = code->c_name;
+
+    return name ? name : "???";
+}
+
 /* Log the message to the configured logger */
 void slog_impl(int priority, const char *file, const char *line, const char *func, const char *format, ...)
 {
@@ -246,6 +259,7 @@ void slog_impl(int priority, const char *file, const char *line, const char *fun
 	switch (gcfg.log_out) {
         default:
 		case LOG_TO_STDOUT:
+            printf("[%s] ", get_priority_name(priority));
 			vprintf(format, ap);
 			break;
 		case LOG_TO_SYSLOG:

--- a/log.h
+++ b/log.h
@@ -1,0 +1,16 @@
+#ifndef __TAYGA_LOG_H__
+#define __TAYGA_LOG_H__
+
+#include <stdarg.h>
+
+#define STRINGIFY_IMPL(x) #x
+#define STRINGIFY(x) STRINGIFY_IMPL(x)
+#define slog(prio, ...) slog_impl(prio, "CODE_FILE=" __FILE__, "CODE_LINE=" STRINGIFY(__LINE__), __func__, __VA_ARGS__)
+
+void slog_impl(int priority, const char *file, const char *line, const char *func, const char *format, ...);
+
+int log_init(void);
+int log_notify_ready(void);
+void log_cleanup(void);
+
+#endif

--- a/nat64.c
+++ b/nat64.c
@@ -66,10 +66,10 @@ struct ip4_error {
 static void log_pkt4(int err, struct pkt *p, const char *msg)
 {
 	const char * type = "";
-	if	   (gcfg->log_opts & err & LOG_OPT_SELF) 	type = "SELF";
-	else if(gcfg->log_opts & err & LOG_OPT_DROP) 	type = "DROP";
-	else if(gcfg->log_opts & err & LOG_OPT_REJECT) 	type = "REJECT";
-	else if(gcfg->log_opts & err & LOG_OPT_ICMP) 	type = "ICMP";
+	if	   (gcfg.log_opts & err & LOG_OPT_SELF) 	type = "SELF";
+	else if(gcfg.log_opts & err & LOG_OPT_DROP) 	type = "DROP";
+	else if(gcfg.log_opts & err & LOG_OPT_REJECT) 	type = "REJECT";
+	else if(gcfg.log_opts & err & LOG_OPT_ICMP) 	type = "ICMP";
 	else return;
 
 	/* Convert the src / dest IPv4 to strings */
@@ -102,10 +102,10 @@ static void log_pkt4(int err, struct pkt *p, const char *msg)
 static void log_pkt6(int err, struct pkt *p, const char *msg)
 {
 	const char * type = "";
-	if	   (gcfg->log_opts & err & LOG_OPT_SELF) 	type = "SELF";
-	else if(gcfg->log_opts & err & LOG_OPT_DROP) 	type = "DROP";
-	else if(gcfg->log_opts & err & LOG_OPT_REJECT) 	type = "REJECT";
-	else if(gcfg->log_opts & err & LOG_OPT_ICMP) 	type = "ICMP";
+	if	   (gcfg.log_opts & err & LOG_OPT_SELF) 	type = "SELF";
+	else if(gcfg.log_opts & err & LOG_OPT_DROP) 	type = "DROP";
+	else if(gcfg.log_opts & err & LOG_OPT_REJECT) 	type = "REJECT";
+	else if(gcfg.log_opts & err & LOG_OPT_ICMP) 	type = "ICMP";
 	else return;
 
 	/* Convert the src / dest IPv6 to strings */
@@ -241,7 +241,7 @@ static void host_send_icmp4(uint8_t tos, struct in_addr *src,
 	iov[0].iov_len = sizeof(header);
 	iov[1].iov_base = data;
 	iov[1].iov_len = data_len;
-	if (writev(gcfg->tun_fd, iov, data_len ? 2 : 1) < 0)
+	if (writev(gcfg.tun_fd, iov, data_len ? 2 : 1) < 0)
 		slog(LOG_WARNING, "error writing packet to tun device: %s\n",
 			strerror(errno));
 }
@@ -263,7 +263,7 @@ static void host_send_icmp4_error(uint8_t type, uint8_t code, uint32_t word,
 	icmp.type = type;
 	icmp.code = code;
 	icmp.word = htonl(word);
-	host_send_icmp4(0, &gcfg->local_addr4, &orig->ip4->src, &icmp,
+	host_send_icmp4(0, &gcfg.local_addr4, &orig->ip4->src, &icmp,
 			(uint8_t *)orig->ip4, orig_len);
 }
 
@@ -328,7 +328,7 @@ static int xlate_payload_4to6(struct pkt *p, struct ip6 *ip6, int em)
 		tck = (uint16_t *)(p->data + 6);
 		if (!*tck) {
 			/* UDP packet has no checksum, how do we deal? */
-			switch(gcfg->udp_cksum_mode) {
+			switch(gcfg.udp_cksum_mode) {
 			default:
 			case UDP_CKSUM_DROP:
 				/* Do not handle zero checksum packets */
@@ -371,9 +371,9 @@ static void xlate_4to6_data(struct pkt *p)
 	uint32_t frag_size;
 	int ret;
 
-	frag_size = gcfg->ipv6_offlink_mtu;
-	if (frag_size > gcfg->mtu)
-		frag_size = gcfg->mtu;
+	frag_size = gcfg.ipv6_offlink_mtu;
+	if (frag_size > gcfg.mtu)
+		frag_size = gcfg.mtu;
 	frag_size -= sizeof(struct ip6);
 
 	ret = map_ip4_to_ip6(&header.ip6.dest, &p->ip4->dest);
@@ -410,9 +410,9 @@ static void xlate_4to6_data(struct pkt *p)
 	   1456 bytes of payload == 1504 bytes.) */
 	if ((off & (IP4_F_MASK | IP4_F_MF)) == 0) {
 		if (off & IP4_F_DF) {
-			if (gcfg->mtu - MTU_ADJ < p->header_len + p->data_len) {
+			if (gcfg.mtu - MTU_ADJ < p->header_len + p->data_len) {
 				log_pkt4(LOG_OPT_ICMP,p,"Packet Too Big");
-				host_send_icmp4_error(3, 4, gcfg->mtu - MTU_ADJ, p);
+				host_send_icmp4_error(3, 4, gcfg.mtu - MTU_ADJ, p);
 				return;
 			}
 			no_frag_hdr = 1;
@@ -435,7 +435,7 @@ static void xlate_4to6_data(struct pkt *p)
 		iov[1].iov_base = p->data;
 		iov[1].iov_len = p->data_len;
 
-		if (writev(gcfg->tun_fd, iov, 2) < 0)
+		if (writev(gcfg.tun_fd, iov, 2) < 0)
 			slog(LOG_WARNING, "error writing packet to tun "
 					"device: %s\n", strerror(errno));
 	} else {
@@ -470,7 +470,7 @@ static void xlate_4to6_data(struct pkt *p)
 							htons(IP4_F_MF)))
 				header.ip6_frag.offset_flags |= htons(IP6_F_MF);
 
-			if (writev(gcfg->tun_fd, iov, 2) < 0) {
+			if (writev(gcfg.tun_fd, iov, 2) < 0) {
 				slog(LOG_WARNING, "error writing packet to "
 						"tun device: %s\n",
 						strerror(errno));
@@ -644,8 +644,8 @@ static void xlate_4to6_icmp_error(struct pkt *p)
 				mtu = est_mtu(ntohs(p_em.ip4->length));
 			mtu += MTU_ADJ;
 			/* Path MTU > our own MTU */
-			if (mtu > gcfg->mtu)
-				mtu = gcfg->mtu;
+			if (mtu > gcfg.mtu)
+				mtu = gcfg.mtu;
 			/* Set MTU to 1280 to prevent generation of atomic fragments */
 			if (mtu < MTU_MIN) {
 				mtu = MTU_MIN;
@@ -705,7 +705,7 @@ static void xlate_4to6_icmp_error(struct pkt *p)
 	if (map_ip4_to_ip6(&header.ip6.src, &p->ip4->src)) {
 		log_pkt4(LOG_OPT_DROP,p,"Need to rely on fake source");
 		//Fake source IP is our own IP
-		header.ip6.src = gcfg->local_addr6;
+		header.ip6.src = gcfg.local_addr6;
 	}
 
 	if (map_ip4_to_ip6(&header.ip6.dest, &p->ip4->dest)) {
@@ -732,7 +732,7 @@ static void xlate_4to6_icmp_error(struct pkt *p)
 	iov[1].iov_base = p_em.data;
 	iov[1].iov_len = p_em.data_len;
 
-	if (writev(gcfg->tun_fd, iov, 2) < 0)
+	if (writev(gcfg.tun_fd, iov, 2) < 0)
 		slog(LOG_WARNING, "error writing packet to tun device: %s\n",
 			strerror(errno));
 }
@@ -753,7 +753,7 @@ void handle_ip4(struct pkt *p)
 	}
 
 	/* Packet for ourselves*/
-	if (p->ip4->dest.s_addr == gcfg->local_addr4.s_addr) {
+	if (p->ip4->dest.s_addr == gcfg.local_addr4.s_addr) {
 		if (p->data_proto == 1)
 			host_handle_icmp4(p);
 		else {
@@ -800,7 +800,7 @@ static void host_send_icmp6(uint8_t tc, struct in6_addr *src,
 	iov[0].iov_len = sizeof(header);
 	iov[1].iov_base = data;
 	iov[1].iov_len = data_len;
-	if (writev(gcfg->tun_fd, iov, data_len ? 2 : 1) < 0)
+	if (writev(gcfg.tun_fd, iov, data_len ? 2 : 1) < 0)
 		slog(LOG_WARNING, "error writing packet to tun device: %s\n",
 			strerror(errno));
 }
@@ -822,7 +822,7 @@ static void host_send_icmp6_error(uint8_t type, uint8_t code, uint32_t word,
 	icmp.type = type;
 	icmp.code = code;
 	icmp.word = htonl(word);
-	host_send_icmp6(0, &gcfg->local_addr6, &orig->ip6->src, &icmp,
+	host_send_icmp6(0, &gcfg.local_addr6, &orig->ip6->src, &icmp,
 			(uint8_t *)orig->ip6, orig_len);
 }
 
@@ -916,7 +916,7 @@ static int xlate_payload_6to4(struct pkt *p, struct ip4 *ip4, int em)
 		tck = (uint16_t *)(p->data + 6);
 		if (!*tck) {
 			/* UDP packet has no checksum, how do we deal? */
-			switch(gcfg->udp_cksum_mode) {
+			switch(gcfg.udp_cksum_mode) {
 			default:
 			case UDP_CKSUM_DROP:
 				/* Do not handle zero checksum packets */
@@ -980,9 +980,9 @@ static void xlate_6to4_data(struct pkt *p)
 		return;
 	}
 
-	if (sizeof(struct ip6) + p->header_len + p->data_len > gcfg->mtu) {
+	if (sizeof(struct ip6) + p->header_len + p->data_len > gcfg.mtu) {
 		log_pkt6(LOG_OPT_ICMP,p,"Packet Too Big");
-		host_send_icmp6_error(2, 0, gcfg->mtu, p);
+		host_send_icmp6_error(2, 0, gcfg.mtu, p);
 		return;
 	}
 
@@ -1001,7 +1001,7 @@ static void xlate_6to4_data(struct pkt *p)
 	iov[1].iov_base = p->data;
 	iov[1].iov_len = p->data_len;
 
-	if (writev(gcfg->tun_fd, iov, 2) < 0)
+	if (writev(gcfg.tun_fd, iov, 2) < 0)
 		slog(LOG_WARNING, "error writing packet to tun device: %s\n",
 			strerror(errno));
 }
@@ -1176,8 +1176,8 @@ static void xlate_6to4_icmp_error(struct pkt *p)
 			log_pkt6(LOG_OPT_DROP,p,"No MTU in Packet Too Big");
 			return;
 		}
-		if (mtu > gcfg->mtu)
-			mtu = gcfg->mtu;
+		if (mtu > gcfg.mtu)
+			mtu = gcfg.mtu;
 		mtu -= MTU_ADJ;
 		header.icmp.word = htonl(mtu);
 		break;
@@ -1246,7 +1246,7 @@ static void xlate_6to4_icmp_error(struct pkt *p)
 	if (map_ip6_to_ip4(&header.ip4.src, &p->ip6->src, 0)) {
 		log_pkt6(LOG_OPT_ICMP,p,"Need to rely on fake source");
 		//fake source IP is our own IP
-		header.ip4.src = gcfg->local_addr4;
+		header.ip4.src = gcfg.local_addr4;
 	}
 
 	if (map_ip6_to_ip4(&header.ip4.dest, &p->ip6->dest, 0)) {
@@ -1273,7 +1273,7 @@ static void xlate_6to4_icmp_error(struct pkt *p)
 	iov[1].iov_base = p_em.data;
 	iov[1].iov_len = p_em.data_len;
 
-	if (writev(gcfg->tun_fd, iov, 2) < 0)
+	if (writev(gcfg.tun_fd, iov, 2) < 0)
 		slog(LOG_WARNING, "error writing packet to tun device: %s\n",
 			strerror(errno));
 }
@@ -1294,7 +1294,7 @@ void handle_ip6(struct pkt *p)
 		return;
 	}
 
-	if (IN6_ARE_ADDR_EQUAL(&p->ip6->dest, &gcfg->local_addr6)) {
+	if (IN6_ARE_ADDR_EQUAL(&p->ip6->dest, &gcfg.local_addr6)) {
 		if (p->data_proto == 58)
 			host_handle_icmp6(p);
 		else {

--- a/tayga.c
+++ b/tayga.c
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
 			pidfile = optarg;
 			break;
 		case 'h':
-			usage(1);
+			usage(0);
 			break;
 		default:
 			die("Try `%s --help' for more information (got %c)", progname,c);

--- a/tayga.c
+++ b/tayga.c
@@ -20,59 +20,12 @@
 
 #include <stdarg.h>
 #include <signal.h>
-#include <getopt.h>
 #include <pwd.h>
 #include <grp.h>
 
 extern struct config *gcfg;
 time_t now;
-static const char *progname;
 static int signalfds[2];
-
-void usage(int code) {
-	int pad = strlen(progname);
-	fprintf(stderr,
-			"TAYGA version %s\n"
-			"Usage:\n"
-			"%s [-c|--config CONFIGFILE] [-d|--debug] [-n|--nodetach]\n"
-			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n"
-			"%*c [--syslog|--stdout|--journal]\n"
-			"%s --mktun [-c|--config CONFIGFILE]\n"
-			"%s --rmtun [-c|--config CONFIGFILE]\n"
-			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n\n"
-			"--config FILE      : Read configuration options from FILE\n"
-			"--debug, -d        : Enable debug messages (implies --nodetach and --stdout)\n"
-			"--nodetach         : Do not fork the process\n"
-			"--syslog           : Log messages to syslog (default)\n"
-			"--stdout           : Log messages to stdout\n"
-			"--journal          : Log messages to the systemd journal\n"
-			"--user USERID      : Set uid to USERID after initialization\n"
-			"--group GROUPID    : Set gid to GROUPID after initialization\n"
-			"--chroot           : chroot() to data-dir (specified in config file)\n"
-			"--pidfile FILE     : Write process ID of daemon to FILE\n"
-			"--mktun            : Create the persistent TUN interface\n"
-			"--rmtun            : Remove the persistent TUN interface\n"
-			"--help, -h         : Show this help message\n",
-		TAYGA_VERSION,
-		progname,
-		pad, ' ',
-		pad, ' ',
-		progname,
-		progname,
-		pad, ' '
-	);
-	exit(code);
-}
-
-/* Used during argument parsing, before logging is setup */
-void die(const char *format, ...) {
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	putc('\n', stderr);
-	exit(1);
-}
 
 static void signal_handler(int signal)
 {
@@ -259,103 +212,23 @@ static void * worker(void * arg)
 int main(int argc, char **argv)
 {
 	int ret;
-	int pidfd;
+	int pidfd = -1;
 	struct pollfd pollfds[2];
 	char addrbuf[INET6_ADDRSTRLEN];
-
-	char *conffile = TAYGA_CONF_PATH;
-	char *user = NULL;
-	char *group = NULL;
-	char *pidfile = NULL;
-	int do_chroot = 0;
-	int detach = 1;
-	int do_mktun = 0;
-	int do_rmtun = 0;
 	struct passwd *pw = NULL;
 	struct group *gr = NULL;
-	progname = argv[0];
 
 	/* Init config structure */
 	if(config_init() < 0) return 1;
 
-	static struct option longopts[] = {
-		{ "mktun", no_argument, NULL, 1 },
-		{ "rmtun", no_argument, NULL, 2 },
-		{ "syslog", no_argument, NULL, 3 },
-		{ "stdout", no_argument, NULL, 4 },
-		{ "journal", no_argument, NULL, 5 },
-		{ "help", no_argument, NULL, 'h' },
-		{ "config", required_argument, NULL, 'c' },
-		{ "nodetach", no_argument, NULL, 'n' },
-		{ "user", required_argument, NULL, 'u' },
-		{ "group", required_argument, NULL, 'g' },
-		{ "chroot", no_argument, NULL, 'r' },
-		{ "pidfile", required_argument, NULL, 'p' },
-		{ "debug", no_argument, NULL, 'd' },
-		{ NULL, 0, NULL, 0 }
-	};
-
-	/* Arg parsing loop */
-	for (int c; c = getopt_long(argc, argv, "c:dhnu:g:rp:", longopts, NULL), c != -1;) {
-		switch (c) {
-		case 1: /* --mktun */
-			do_mktun = 1;
-			break;
-		case 2: /* --rmtun */
-			do_rmtun = 1;
-			break;
-		case 3: /* --syslog */
-			gcfg->log_out = LOG_TO_SYSLOG;
-			break;
-		case 4: /* --stdout */
-			gcfg->log_out = LOG_TO_STDOUT;
-			break;
-		case 5: /* --journal */
-			gcfg->log_out = LOG_TO_JOURNAL;
-			break;
-		case 'c':
-			conffile = optarg;
-			break;
-		case 'd':
-			gcfg->log_out = LOG_TO_STDOUT;
-			detach = 0;
-			break;
-		case 'n':
-			detach = 0;
-			break;
-		case 'u':
-			user = optarg;
-			break;
-		case 'g':
-			group = optarg;
-			break;
-		case 'r':
-			do_chroot = 1;
-			break;
-		case 'p':
-			pidfile = optarg;
-			break;
-		case 'h':
-			usage(0);
-			break;
-		default:
-			die("Try `%s --help' for more information", progname);
-		}
-	}
-
-	if (do_mktun && do_rmtun) {
-		die("Error: both --mktun and --rmtun specified");
-	}
+	/* Parse command line arguments */
+	cmdline_parse(argc, argv);
 
 	/* Setup logging
-	 * But not if we are only doing mktun / rmtun
 	 * This must be done before config parsing, since those rely
 	 * on logging based on log_out
 	 */
-	if(do_mktun || do_rmtun) {
-		//Force stdout for these options
-		gcfg->log_out = LOG_TO_STDOUT;
-	} else if (gcfg->log_out == LOG_TO_SYSLOG) {
+	if (gcfg->log_out == LOG_TO_SYSLOG) {
 		openlog("tayga", LOG_PID | LOG_NDELAY, LOG_DAEMON);
 	} else if (gcfg->log_out == LOG_TO_JOURNAL) {
 		int r = journal_init("tayga");
@@ -366,7 +239,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Parse config file options */
-	if(config_read(conffile) < 0) return 1;
+	if(config_read(arg_conffile) < 0) return 1;
 
 	/* Validate config (and load map file) */
 	if(config_validate() < 0) return 1;
@@ -374,47 +247,35 @@ int main(int argc, char **argv)
 	/* Check if we are doing tunnel operations only
 	 * Must be done after config reading so we know tun name
 	 */
-	if (do_mktun || do_rmtun) {
-		if (user) {
-			die("Error: cannot specify -u or --user "
-					"with mktun/rmtun operation");
-		}
-		if (group) {
-			die("Error: cannot specify -g or --group "
-					"with mktun/rmtun operation");
-		}
-		if (do_chroot) {
-			die("Error: cannot specify -r or --chroot "
-					"with mktun/rmtun operation");
-		}
-		if(tun_setup(do_mktun, do_rmtun)) return 1;
+	if (arg_do_mktun || arg_do_rmtun) {
+		if(tun_setup(arg_do_mktun, arg_do_rmtun)) return 1;
 		return 0;
 	}
 
 	/* Change user */
-	if (user) {
-		pw = getpwnam(user);
+	if (arg_user) {
+		pw = getpwnam(arg_user);
 		if (!pw) {
-			slog(LOG_CRIT, "Error: user %s does not exist\n", user);
+			slog(LOG_CRIT, "Error: user %s does not exist\n", arg_user);
 			return 1;
 		}
 	}
 
 	/* Change group */
-	if (group) {
-		gr = getgrnam(group);
+	if (arg_group) {
+		gr = getgrnam(arg_group);
 		if (!gr) {
 			slog(LOG_CRIT, "Error: group %s does not exist\n",
-					group);
+					arg_group);
 			return 1;
 		}
 	}
 
 	/* Chroot */
 	if (!gcfg->data_dir[0]) {
-		if (do_chroot) {
+		if (arg_do_chroot) {
 			slog(LOG_CRIT, "Error: cannot chroot when no data-dir "
-					"is specified in %s\n", conffile);
+					"is specified in %s\n", arg_conffile);
 			return 1;
 		}
 		if (chdir("/")) {
@@ -423,7 +284,7 @@ int main(int argc, char **argv)
 			return 1;
 		}
 	} else if (chdir(gcfg->data_dir) < 0) {
-		if (user || errno != ENOENT) {
+		if (arg_user || errno != ENOENT) {
 			slog(LOG_CRIT, "Error: unable to chdir to %s, "
 					"aborting: %s\n", gcfg->data_dir,
 					strerror(errno));
@@ -443,7 +304,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (do_chroot && (!pw || pw->pw_uid == 0)) {
+	if (arg_do_chroot && (!pw || pw->pw_uid == 0)) {
 		slog(LOG_CRIT, "Error: chroot is ineffective without also "
 				"specifying the -u option to switch to an "
 				"unprivileged user\n");
@@ -457,23 +318,23 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (pidfile) {
-		pidfd = open(pidfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (arg_pidfile) {
+		pidfd = open(arg_pidfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 		if (pidfd < 0) {
 			slog(LOG_CRIT, "Error, unable to open %s for "
-					"writing: %s\n", pidfile,
+					"writing: %s\n", arg_pidfile,
 					strerror(errno));
 			exit(1);
 		}
 	}
 
-	if (detach && daemon(1, 0) < 0) {
+	if (arg_detach && daemon(1, 0) < 0) {
 		slog(LOG_CRIT, "Error, unable to fork and detach: %s\n",
 				strerror(errno));
 		exit(1);
 	}
 
-	if (pidfile) {
+	if (pidfd >= 0) {
 		snprintf(addrbuf, sizeof(addrbuf), "%ld\n", (long)getpid());
 		if (write(pidfd, addrbuf, strlen(addrbuf)) != (ssize_t)strlen(addrbuf)) {
 			slog(LOG_CRIT, "Error, unable to write PID file.\n");
@@ -524,7 +385,7 @@ int main(int argc, char **argv)
 
 	if(tun_setup(0, 0)) exit(1);
 
-	if (do_chroot) {
+	if (arg_do_chroot) {
 		if (chroot(gcfg->data_dir) < 0) {
 			slog(LOG_CRIT, "Unable to chroot to %s: %s\n",
 					gcfg->data_dir, strerror(errno));

--- a/tayga.c
+++ b/tayga.c
@@ -30,15 +30,16 @@ static const char *progname;
 static int signalfds[2];
 
 void usage(int code) {
+	int pad = strlen(progname);
 	fprintf(stderr,
 			"TAYGA version %s\n"
 			"Usage:\n"
 			"%s [-c|--config CONFIGFILE] [-d|--debug] [-n|--nodetach]\n"
-			"       [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n"
-			"       [--syslog|--stdout|--journal]\n"
+			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n"
+			"%*c [--syslog|--stdout|--journal]\n"
 			"%s --mktun [-c|--config CONFIGFILE]\n"
 			"%s --rmtun [-c|--config CONFIGFILE]\n"
-			"       [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n\n"
+			"%*c [-u|--user USERID] [-g|--group GROUPID] [-r|--chroot] [-p|--pidfile PIDFILE]\n\n"
 			"--config FILE      : Read configuration options from FILE\n"
 			"--debug, -d        : Enable debug messages (implies --nodetach and --stdout)\n"
 			"--nodetach         : Do not fork the process\n"
@@ -52,7 +53,14 @@ void usage(int code) {
 			"--mktun            : Create the persistent TUN interface\n"
 			"--rmtun            : Remove the persistent TUN interface\n"
 			"--help, -h         : Show this help message\n",
-		TAYGA_VERSION, progname, progname, progname);
+		TAYGA_VERSION,
+		progname,
+		pad, ' ',
+		pad, ' ',
+		progname,
+		progname,
+		pad, ' '
+	);
 	exit(code);
 }
 

--- a/tayga.c
+++ b/tayga.c
@@ -86,11 +86,7 @@ static void signal_read(void)
 			dynamic_maint(gcfg.dynamic_pool, 1);
 		}
 		slog(LOG_NOTICE, "Exiting on signal %d\n", sig);
-		if (gcfg.log_out == LOG_TO_SYSLOG) {
-			closelog();
-		} else if (gcfg.log_out == LOG_TO_JOURNAL) {
-			journal_cleanup();
-		}
+		log_cleanup();
 		exit(0);
 	}
 }
@@ -223,18 +219,11 @@ int main(int argc, char **argv)
 	/* Parse command line arguments */
 	cmdline_parse(argc, argv);
 
-	/* Setup logging
-	 * This must be done before config parsing, since those rely
-	 * on logging based on log_out
-	 */
-	if (gcfg.log_out == LOG_TO_SYSLOG) {
-		openlog("tayga", LOG_PID | LOG_NDELAY, LOG_DAEMON);
-	} else if (gcfg.log_out == LOG_TO_JOURNAL) {
-		int r = journal_init("tayga");
-		if (r < 0) {
-			fprintf(stderr,"Error: Unable to initialize journal: %s\n", strerror(-r));
-			return 1;
-		}
+	/* Init logging infrastructure */
+	ret = log_init();
+	if (ret < 0) {
+		fprintf(stderr, "Error: Unable to initialize log: %s\n", strerror(-ret));
+		return 1;
 	}
 
 	/* Parse config file options */
@@ -451,13 +440,11 @@ int main(int argc, char **argv)
 	pollfds[1].fd = gcfg.tun_fd;
 	pollfds[1].events = POLLIN;
 
-	/* Tell systemd logger we are ready */
-	if(gcfg.log_out == LOG_TO_JOURNAL) {
-		int r = notify("READY=1");
-		if (r < 0) {
-			slog(LOG_CRIT, "Failed to notify readiness to $NOTIFY_SOCKET: %s\n", strerror(-r));
-			exit(1);
-		}
+	/* Tell the logger we are ready */
+	ret = log_notify_ready();
+	if (ret < 0) {
+		slog(LOG_CRIT, "Failed to notify readiness: %s\n", strerror(-ret));
+		exit(1);
 	}
 
 #ifdef __linux__

--- a/tayga.c
+++ b/tayga.c
@@ -400,11 +400,11 @@ int main(int argc, char **argv)
 		}
 		if (group) {
 			die("Error: cannot specify -g or --group "
-					"with mktun/rmtun operation\n");
+					"with mktun/rmtun operation");
 		}
 		if (do_chroot) {
 			die("Error: cannot specify -r or --chroot "
-					"with mktun/rmtun operation\n");
+					"with mktun/rmtun operation");
 		}
 		if(tun_setup(do_mktun, do_rmtun)) return 1;
 		return 0;

--- a/tayga.c
+++ b/tayga.c
@@ -318,7 +318,6 @@ int main(int argc, char **argv)
 				case 1: /* --rmtun */
 					if (do_mktun) {
 						die("Error: both --mktun and --rmtun specified");
-						exit(1);
 					}
 					do_rmtun = 1;
 					break;
@@ -361,8 +360,7 @@ int main(int argc, char **argv)
 			usage(1);
 			break;
 		default:
-			die("Try `%s --help' for more information (got %c)", argv[0],c);
-			exit(1);
+			die("Try `%s --help' for more information (got %c)", progname,c);
 		}
 	}
 

--- a/tayga.c
+++ b/tayga.c
@@ -23,7 +23,6 @@
 #include <pwd.h>
 #include <grp.h>
 
-extern struct config *gcfg;
 time_t now;
 static int signalfds[2];
 
@@ -78,18 +77,18 @@ static void signal_read(void)
 			/* Reload map-file */
 			addrmap_reload();
 			/* Dynamic map flush to file */
-			if (gcfg->dynamic_pool)
-				dynamic_maint(gcfg->dynamic_pool, 1);
+			if (gcfg.dynamic_pool)
+				dynamic_maint(gcfg.dynamic_pool, 1);
 			continue;
 		}
 		/* For any other signal prepare to exit cleanly */
-		if (gcfg->dynamic_pool) {
-			dynamic_maint(gcfg->dynamic_pool, 1);
+		if (gcfg.dynamic_pool) {
+			dynamic_maint(gcfg.dynamic_pool, 1);
 		}
 		slog(LOG_NOTICE, "Exiting on signal %d\n", sig);
-		if (gcfg->log_out == LOG_TO_SYSLOG) {
+		if (gcfg.log_out == LOG_TO_SYSLOG) {
 			closelog();
-		} else if (gcfg->log_out == LOG_TO_JOURNAL) {
+		} else if (gcfg.log_out == LOG_TO_JOURNAL) {
 			journal_cleanup();
 		}
 		exit(0);
@@ -108,11 +107,11 @@ static void print_op_info(void)
 	static const char * map_origins[] = MAP_ORIGIN_LIST;
 	unsigned int type, origin;
 
-	inet_ntop(AF_INET, &gcfg->local_addr4, addrbuf, sizeof(addrbuf));
+	inet_ntop(AF_INET, &gcfg.local_addr4, addrbuf, sizeof(addrbuf));
 	slog(LOG_INFO, "TAYGA's IPv4 address: %s\n", addrbuf);
-	inet_ntop(AF_INET6, &gcfg->local_addr6, addrbuf, sizeof(addrbuf));
+	inet_ntop(AF_INET6, &gcfg.local_addr6, addrbuf, sizeof(addrbuf));
 	slog(LOG_INFO, "TAYGA's IPv6 address: %s\n", addrbuf);
-	m6 = list_entry(gcfg->map6_list.prev, struct map6, list);
+	m6 = list_entry(gcfg.map6_list.prev, struct map6, list);
 	if (m6->type == MAP_TYPE_RFC6052) {
 		inet_ntop(AF_INET6, &m6->addr, addrbuf, sizeof(addrbuf));
 		slog(LOG_INFO, "NAT64 prefix: %s/%d\n",
@@ -120,7 +119,7 @@ static void print_op_info(void)
 		if (m6->addr.s6_addr32[0] == WKPF
 			&& !m6->addr.s6_addr32[1]
 			&& !m6->addr.s6_addr32[2]
-			&& gcfg->wkpf_strict)
+			&& gcfg.wkpf_strict)
 			slog(LOG_NOTICE, "Note: traffic between IPv6 hosts and "
 					"private IPv4 addresses (i.e. to/from "
 					"64:ff9b::10.0.0.0/104, "
@@ -132,12 +131,12 @@ static void print_op_info(void)
 					"IPv6 hosts to communicate with "
 					"private IPv4 addresses.\n");
 	}
-	if (gcfg->dynamic_pool) {
-		inet_ntop(AF_INET, &gcfg->dynamic_pool->map4.addr,
+	if (gcfg.dynamic_pool) {
+		inet_ntop(AF_INET, &gcfg.dynamic_pool->map4.addr,
 				addrbuf, sizeof(addrbuf));
 		slog(LOG_INFO, "Dynamic pool: %s/%d\n", addrbuf,
-				gcfg->dynamic_pool->map4.prefix_len);
-		if (!gcfg->data_dir[0])
+				gcfg.dynamic_pool->map4.prefix_len);
+		if (!gcfg.data_dir[0])
 			slog(LOG_NOTICE, "Note: dynamically-assigned mappings "
 					"will not be saved across restarts.  "
 					"Specify data-dir in config if you would "
@@ -146,7 +145,7 @@ static void print_op_info(void)
 	}
 
 	slog(LOG_DEBUG,"Map4 List:\n");
-	list_for_each(entry, &gcfg->map4_list) {
+	list_for_each(entry, &gcfg.map4_list) {
 		s4 = list_entry(entry, struct map4, list);
 		type = (unsigned int)s4->type;
 		type = (type > MAP_TYPE_MAX) ? MAP_TYPE_MAX : type;
@@ -167,7 +166,7 @@ static void print_op_info(void)
 		}
 	}
 	slog(LOG_DEBUG,"Map6 List:\n");
-	list_for_each(entry, &gcfg->map6_list) {
+	list_for_each(entry, &gcfg.map6_list) {
 		s6 = list_entry(entry, struct map6, list);
 		type = (unsigned int)s6->type;
 		type = (type > MAP_TYPE_MAX) ? MAP_TYPE_MAX : type;
@@ -204,7 +203,7 @@ static void * worker(void * arg)
 	/* Enter worker loop */
 	slog(LOG_DEBUG,"Starting worker thread %d\n",idx);
 	for (;;) {
-		tun_read(recv_buf,gcfg->tun_fd_addl[idx]);
+		tun_read(recv_buf,gcfg.tun_fd_addl[idx]);
 	}	
 }
 #endif //__linux__
@@ -219,7 +218,7 @@ int main(int argc, char **argv)
 	struct group *gr = NULL;
 
 	/* Init config structure */
-	if(config_init() < 0) return 1;
+	config_init();
 
 	/* Parse command line arguments */
 	cmdline_parse(argc, argv);
@@ -228,9 +227,9 @@ int main(int argc, char **argv)
 	 * This must be done before config parsing, since those rely
 	 * on logging based on log_out
 	 */
-	if (gcfg->log_out == LOG_TO_SYSLOG) {
+	if (gcfg.log_out == LOG_TO_SYSLOG) {
 		openlog("tayga", LOG_PID | LOG_NDELAY, LOG_DAEMON);
-	} else if (gcfg->log_out == LOG_TO_JOURNAL) {
+	} else if (gcfg.log_out == LOG_TO_JOURNAL) {
 		int r = journal_init("tayga");
 		if (r < 0) {
 			fprintf(stderr,"Error: Unable to initialize journal: %s\n", strerror(-r));
@@ -272,7 +271,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Chroot */
-	if (!gcfg->data_dir[0]) {
+	if (!gcfg.data_dir[0]) {
 		if (arg_do_chroot) {
 			slog(LOG_CRIT, "Error: cannot chroot when no data-dir "
 					"is specified in %s\n", arg_conffile);
@@ -283,22 +282,22 @@ int main(int argc, char **argv)
 					strerror(errno));
 			return 1;
 		}
-	} else if (chdir(gcfg->data_dir) < 0) {
+	} else if (chdir(gcfg.data_dir) < 0) {
 		if (arg_user || errno != ENOENT) {
 			slog(LOG_CRIT, "Error: unable to chdir to %s, "
-					"aborting: %s\n", gcfg->data_dir,
+					"aborting: %s\n", gcfg.data_dir,
 					strerror(errno));
 			return 1;
 		}
-		if (mkdir(gcfg->data_dir, 0777) < 0) {
+		if (mkdir(gcfg.data_dir, 0777) < 0) {
 			slog(LOG_CRIT, "Error: unable to create %s, aborting: "
-					"%s\n", gcfg->data_dir,
+					"%s\n", gcfg.data_dir,
 					strerror(errno));
 			return 1;
 		}
-		if (chdir(gcfg->data_dir) < 0) {
+		if (chdir(gcfg.data_dir) < 0) {
 			slog(LOG_CRIT, "Error: created %s but unable to chdir "
-					"to it!?? (%s)\n", gcfg->data_dir,
+					"to it!?? (%s)\n", gcfg.data_dir,
 					strerror(errno));
 			return 1;
 		}
@@ -312,9 +311,9 @@ int main(int argc, char **argv)
 	}
 
 	/* If using a map-file, read it after doing chroot/chdir */
-	if(gcfg->map_file[0] && addrmap_reload() != ERROR_NONE) {
+	if(gcfg.map_file[0] && addrmap_reload() != ERROR_NONE) {
 		slog(LOG_CRIT, "Error: map-file %s is configured but not readable\n",
-			gcfg->map_file);
+			gcfg.map_file);
 		return 1;
 	}
 
@@ -347,7 +346,7 @@ int main(int argc, char **argv)
 	slog(LOG_DEBUG, "Compiled from " TAYGA_BRANCH "\n");
 	slog(LOG_DEBUG, "Commit " TAYGA_COMMIT "\n");
 
-	if (gcfg->cache_size) {
+	if (gcfg.cache_size) {
 		int urandom_fd = open("/dev/urandom", O_RDONLY);
 		if (urandom_fd < 0) {
 			slog(LOG_CRIT, "Unable to open /dev/urandom, "
@@ -355,7 +354,7 @@ int main(int argc, char **argv)
 			exit(1);
 		}		
 		int len = 8 * sizeof(uint32_t);
-		int ret = read(urandom_fd, gcfg->rand, len);
+		int ret = read(urandom_fd, gcfg.rand, len);
 		if (ret < 0) {
 			slog(LOG_CRIT, "read /dev/urandom returned %s\n",
 					strerror(errno));
@@ -366,11 +365,11 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 
-		gcfg->rand[0] |= 1; /* need an odd number for IPv4 hash */
+		gcfg.rand[0] |= 1; /* need an odd number for IPv4 hash */
 	}
 	
 	/* If workers is -1 (default), set to cpu cores */
-	if(gcfg->workers < 0) {
+	if(gcfg.workers < 0) {
 		int cpu_cores = sysconf(_SC_NPROCESSORS_ONLN);
 		if(cpu_cores > MAX_WORKERS) cpu_cores = MAX_WORKERS;
 		if(cpu_cores < 0) {
@@ -380,15 +379,15 @@ int main(int argc, char **argv)
 		else {
 			slog(LOG_DEBUG,"Using %d workers based on CPU core count\n",cpu_cores);
 		}
-		gcfg->workers = cpu_cores;
+		gcfg.workers = cpu_cores;
 	}
 
 	if(tun_setup(0, 0)) exit(1);
 
 	if (arg_do_chroot) {
-		if (chroot(gcfg->data_dir) < 0) {
+		if (chroot(gcfg.data_dir) < 0) {
 			slog(LOG_CRIT, "Unable to chroot to %s: %s\n",
-					gcfg->data_dir, strerror(errno));
+					gcfg.data_dir, strerror(errno));
 			exit(1);
 		}
 		if (chdir("/")) {
@@ -423,18 +422,18 @@ int main(int argc, char **argv)
 	print_op_info();
 
 	/* Load dynamic maps if configured */
-	if (gcfg->data_dir[0])
-		load_dynamic(gcfg->dynamic_pool);
+	if (gcfg.data_dir[0])
+		load_dynamic(gcfg.dynamic_pool);
 
-	if (gcfg->cache_size)
+	if (gcfg.cache_size)
 		create_cache();
 
 	/* Initialize mutexes */
-	if (pthread_mutex_init(&gcfg->cache_mutex, NULL) != 0) {
+	if (pthread_mutex_init(&gcfg.cache_mutex, NULL) != 0) {
 		slog(LOG_CRIT, "Failed to initialize cache mutex\n");
 		exit(1);
 	}
-	if (pthread_mutex_init(&gcfg->map_mutex, NULL) != 0) {
+	if (pthread_mutex_init(&gcfg.map_mutex, NULL) != 0) {
 		slog(LOG_CRIT, "Failed to initialize map mutex\n");
 		exit(1);
 	}
@@ -449,11 +448,11 @@ int main(int argc, char **argv)
 	memset(pollfds, 0, 2 * sizeof(struct pollfd));
 	pollfds[0].fd = signalfds[0];
 	pollfds[0].events = POLLIN;
-	pollfds[1].fd = gcfg->tun_fd;
+	pollfds[1].fd = gcfg.tun_fd;
 	pollfds[1].events = POLLIN;
 
 	/* Tell systemd logger we are ready */
-	if(gcfg->log_out == LOG_TO_JOURNAL) {
+	if(gcfg.log_out == LOG_TO_JOURNAL) {
 		int r = notify("READY=1");
 		if (r < 0) {
 			slog(LOG_CRIT, "Failed to notify readiness to $NOTIFY_SOCKET: %s\n", strerror(-r));
@@ -464,9 +463,9 @@ int main(int argc, char **argv)
 #ifdef __linux__
 	/* Launch worker threads */
 	static int thread_ids[MAX_WORKERS];
-	for(int i = 0; i < gcfg->workers; i++) {
+	for(int i = 0; i < gcfg.workers; i++) {
 		thread_ids[i] = i;
-		ret = pthread_create(&gcfg->threads[i], NULL, worker, &thread_ids[i]);
+		ret = pthread_create(&gcfg.threads[i], NULL, worker, &thread_ids[i]);
 		if (ret != 0) {
 			slog(LOG_CRIT, "Failed to create worker thread %d: %s\n", 
 				i, strerror(ret));
@@ -489,18 +488,18 @@ int main(int argc, char **argv)
 		if (pollfds[0].revents)
 			signal_read();
 		if (pollfds[1].revents)
-			tun_read(recv_buf,gcfg->tun_fd);
-		if (gcfg->cache_size && (gcfg->last_cache_maint +
+			tun_read(recv_buf,gcfg.tun_fd);
+		if (gcfg.cache_size && (gcfg.last_cache_maint +
 						CACHE_CHECK_INTERVAL < now ||
-					gcfg->last_cache_maint > now)) {
+					gcfg.last_cache_maint > now)) {
 			addrmap_maint();
-			gcfg->last_cache_maint = now;
+			gcfg.last_cache_maint = now;
 		}
-		if (gcfg->dynamic_pool && (gcfg->last_dynamic_maint +
+		if (gcfg.dynamic_pool && (gcfg.last_dynamic_maint +
 						POOL_CHECK_INTERVAL < now ||
-					gcfg->last_dynamic_maint > now)) {
-			dynamic_maint(gcfg->dynamic_pool, 0);
-			gcfg->last_dynamic_maint = now;
+					gcfg.last_dynamic_maint > now)) {
+			dynamic_maint(gcfg.dynamic_pool, 0);
+			gcfg.last_dynamic_maint = now;
 		}
 	}
 	return 0;

--- a/tayga.c
+++ b/tayga.c
@@ -258,7 +258,7 @@ static void * worker(void * arg)
 
 int main(int argc, char **argv)
 {
-	int c, ret, longind;
+	int ret;
 	int pidfd;
 	struct pollfd pollfds[2];
 	char addrbuf[INET6_ADDRSTRLEN];
@@ -279,60 +279,39 @@ int main(int argc, char **argv)
 	if(config_init() < 0) return 1;
 
 	static struct option longopts[] = {
-		{ "mktun", 0, 0, 0 },
-		{ "rmtun", 0, 0, 0 },
-		{ "syslog", 0, 0, 0 },
-		{ "stdout", 0, 0, 0 },
-		{ "journal", 0, 0, 0 },
-		{ "help", 0, 0, 'h' },
-		{ "syslog", 0, 0, 0 },
-		{ "stdout", 0, 0, 0 },
-		{ "journal", 0, 0, 0 },
-		{ "help", 0, 0, 'h' },
-		{ "config", 1, 0, 'c' },
-		{ "nodetach", 0, 0, 'n' },
-		{ "user", 1, 0, 'u' },
-		{ "group", 1, 0, 'g' },
-		{ "chroot", 0, 0, 'r' },
-		{ "pidfile", 1, 0, 'p' },
-		{ "debug", 0, 0, 'd' },
-		{ "debug", 0, 0, 'd' },
-		{ 0, 0, 0, 0 }
+		{ "mktun", no_argument, NULL, 1 },
+		{ "rmtun", no_argument, NULL, 2 },
+		{ "syslog", no_argument, NULL, 3 },
+		{ "stdout", no_argument, NULL, 4 },
+		{ "journal", no_argument, NULL, 5 },
+		{ "help", no_argument, NULL, 'h' },
+		{ "config", required_argument, NULL, 'c' },
+		{ "nodetach", no_argument, NULL, 'n' },
+		{ "user", required_argument, NULL, 'u' },
+		{ "group", required_argument, NULL, 'g' },
+		{ "chroot", no_argument, NULL, 'r' },
+		{ "pidfile", required_argument, NULL, 'p' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ NULL, 0, NULL, 0 }
 	};
 
 	/* Arg parsing loop */
-	for (;;) {
-		c = getopt_long(argc, argv, "c:dhnu:g:rp:", longopts, &longind);
-		/* Reached last argument, terminate loop */
-		if (c == -1)
-			break;
+	for (int c; c = getopt_long(argc, argv, "c:dhnu:g:rp:", longopts, NULL), c != -1;) {
 		switch (c) {
-		case 0:
-			switch (longind) {
-				case 0: /* --mktun */
-					if (do_rmtun) {
-						die("Error: both --mktun and --rmtun specified");
-					}
-					do_mktun = 1;
-					break;
-				case 1: /* --rmtun */
-					if (do_mktun) {
-						die("Error: both --mktun and --rmtun specified");
-					}
-					do_rmtun = 1;
-					break;
-				case 2: /* --syslog */
-					gcfg->log_out = LOG_TO_SYSLOG;
-					break;
-				case 3: /* --stdout */
-					gcfg->log_out = LOG_TO_STDOUT;
-					break;
-				case 4: /* --journal */
-					gcfg->log_out = LOG_TO_JOURNAL;
-					break;
-				default:
-					usage(1);
-			}
+		case 1: /* --mktun */
+			do_mktun = 1;
+			break;
+		case 2: /* --rmtun */
+			do_rmtun = 1;
+			break;
+		case 3: /* --syslog */
+			gcfg->log_out = LOG_TO_SYSLOG;
+			break;
+		case 4: /* --stdout */
+			gcfg->log_out = LOG_TO_STDOUT;
+			break;
+		case 5: /* --journal */
+			gcfg->log_out = LOG_TO_JOURNAL;
 			break;
 		case 'c':
 			conffile = optarg;
@@ -360,8 +339,12 @@ int main(int argc, char **argv)
 			usage(0);
 			break;
 		default:
-			die("Try `%s --help' for more information (got %c)", progname,c);
+			die("Try `%s --help' for more information", progname);
 		}
+	}
+
+	if (do_mktun && do_rmtun) {
+		die("Error: both --mktun and --rmtun specified");
 	}
 
 	/* Setup logging

--- a/tayga.h
+++ b/tayga.h
@@ -228,7 +228,7 @@ struct map4 {
 	struct in_addr mask;
 	int prefix_len;
 	int type;
-	struct list_head list; /* gcfg->map4_list */
+	struct list_head list; /* gcfg.map4_list */
 };
 
 /// Mapping entry (IPv6)
@@ -237,7 +237,7 @@ struct map6 {
 	struct in6_addr mask;
 	int prefix_len;
 	int type;
-	struct list_head list; /* gcfg->map6_list */
+	struct list_head list; /* gcfg.map6_list */
 };
 
 /// Origin of static mapping entry
@@ -294,23 +294,23 @@ struct cache_entry {
 	time_t last_use;
 	uint32_t flags;
 	uint16_t ip4_ident;
-	struct list_head list;  /* gcfg->cache_active or gcfg->cache_pool */
-	struct list_head hash4; /* gcfg->hash_table4 */
-	struct list_head hash6; /* gcfg->hash_table6 */
+	struct list_head list;  /* gcfg.cache_active or gcfg.cache_pool */
+	struct list_head hash4; /* gcfg.hash_table4 */
+	struct list_head hash6; /* gcfg.hash_table6 */
 };
 
 /// IP Address or Route Entry (IPv4)
 struct tun_ip4 {
 	struct in_addr addr;
 	int prefix_len;
-	struct list_head list; /* gcfg->tun_ip4_list and gcfg->tun_rt4_list */
+	struct list_head list; /* gcfg.tun_ip4_list and gcfg.tun_rt4_list */
 };
 
 /// IP Address or Route Entry (IPv6)
 struct tun_ip6 {
 	struct in6_addr addr;
 	int prefix_len;
-	struct list_head list; /* gcfg->tun_ip6_list and gcfg->tun_rt6_list */
+	struct list_head list; /* gcfg.tun_ip6_list and gcfg.tun_rt6_list */
 };
 
 /// Cache flag bits
@@ -435,7 +435,7 @@ enum {
 
 
 /* TAYGA function prototypes */
-extern struct config *gcfg;
+extern struct config gcfg;
 extern time_t now;
 
 /* addrmap.c */
@@ -457,7 +457,7 @@ void addrmap_maint(void);
 int addrmap_reload(void);
 
 /* conffile.c */
-int config_init(void);
+void config_init(void);
 int config_read(char *conffile);
 int config_validate(void);
 

--- a/tayga.h
+++ b/tayga.h
@@ -55,6 +55,7 @@
 
 #include "list.h"
 #include "cmdline.h"
+#include "log.h"
 
 #ifdef COVERAGE_TESTING
 //for coverage testing
@@ -469,18 +470,6 @@ void dynamic_maint(struct dynamic_pool *pool, int shutdown);
 /* nat64.c */
 void handle_ip4(struct pkt *p);
 void handle_ip6(struct pkt *p);
-
-/* log.c */
-#define STRINGIFY_IMPL(x) #x
-#define STRINGIFY(x) STRINGIFY_IMPL(x)
-#define slog(prio, ...) slog_impl(prio, "CODE_FILE=" __FILE__, "CODE_LINE=" STRINGIFY(__LINE__), __func__, __VA_ARGS__)
-void slog_impl(int priority, const char *file, const char *line, const char *func, const char *format, ...);
-int notify(const char *msg);
-int journal_init(const char *progname);
-void journal_cleanup(void);
-int journal_printv_with_location(
-        int priority, const char *file, const char *line, const char *func,
-        const char *format, va_list ap);
 
 /* tun.c */
 int tun_setup(int do_mktun, int do_rmtun);

--- a/tayga.h
+++ b/tayga.h
@@ -52,7 +52,9 @@
 #else
 #error "Could not find headers for platform"
 #endif
+
 #include "list.h"
+#include "cmdline.h"
 
 #ifdef COVERAGE_TESTING
 //for coverage testing

--- a/tayga.h
+++ b/tayga.h
@@ -396,6 +396,15 @@ enum {
 	LOG_OPT_ICMP   = (1<<2),	//Packet kicked back an ICMP for any reason
 	LOG_OPT_SELF   = (1<<3),	//Packet was destined to ourselves
 	LOG_OPT_DYN    = (1<<4),	//Events involving dynamic pool
+
+	LOG_OPT_ALL    = (			//Log everything
+		LOG_OPT_REJECT
+		| LOG_OPT_DROP
+		| LOG_OPT_ICMP
+		| LOG_OPT_SELF
+		| LOG_OPT_DYN
+	),
+
 	LOG_OPT_CONFIG = (1<<15),	//Log has been configured (used in conf file validation)
 };
 

--- a/test/unit_conffile.c
+++ b/test/unit_conffile.c
@@ -1038,7 +1038,7 @@ void test_config_read(void) {
 #else
     tcfg.workers = -1;
 #endif
-    tcfg.log_opts = (LOG_OPT_DROP | LOG_OPT_ICMP | LOG_OPT_REJECT | LOG_OPT_SELF | LOG_OPT_DYN | LOG_OPT_CONFIG);
+    tcfg.log_opts = (LOG_OPT_ALL | LOG_OPT_CONFIG);
     tcfg.tun_up = 1;
     tmap4[0] = "192.168.5.42/32 type 0 mask 255.255.255.255";
     tmap4[1] = "192.168.255.0/24 type 2 mask 255.255.255.0";

--- a/test/unit_conffile.c
+++ b/test/unit_conffile.c
@@ -74,41 +74,37 @@ char * getenv(const char * var) {
 
 /* Function to compare tcfg to gcfg */
 void test_config_compare(void) {
-    /* Check pointer */
-    expect(gcfg != NULL,"GCFG is not null");
-    if(!gcfg) return;
-
     /* Compare every field in the struct */
-    expects(gcfg->tundev, tcfg.tundev, IFNAMSIZ, "tundev");
-    expects(gcfg->data_dir, tcfg.data_dir, 512, "data_dir");
-    expects(gcfg->map_file, tcfg.map_file, 512, "map_file");
-    expectl(gcfg->local_addr4.s_addr, tcfg.local_addr4.s_addr, "local_addr4");
-    expectl(gcfg->local_addr6.s6_addr32[0],tcfg.local_addr6.s6_addr32[0], "local_addr6[0]");
-    expectl(gcfg->local_addr6.s6_addr32[1],tcfg.local_addr6.s6_addr32[1], "local_addr6[1]");
-    expectl(gcfg->local_addr6.s6_addr32[2],tcfg.local_addr6.s6_addr32[2], "local_addr6[2]");
-    expectl(gcfg->local_addr6.s6_addr32[3],tcfg.local_addr6.s6_addr32[3], "local_addr6[3]");
-    expectl(gcfg->dyn_min_lease, tcfg.dyn_min_lease, "dyn_min_lease");
-    expectl(gcfg->dyn_max_lease, tcfg.dyn_max_lease, "dyn_max_lease");
-    expectl(gcfg->max_commit_delay, tcfg.max_commit_delay, "max_commit_delay");
-    expectl(gcfg->hash_bits,tcfg.hash_bits, "hash_bits");
-    expectl(gcfg->cache_size,tcfg.cache_size, "cache_size");
-    expectl(gcfg->ipv6_offlink_mtu,tcfg.ipv6_offlink_mtu, "ipv6_offlink_mtu");
-    expectl(gcfg->workers,tcfg.workers, "workers");
-    expectl(gcfg->mtu,tcfg.mtu, "mtu");
-    expectl(gcfg->wkpf_strict, tcfg.wkpf_strict, "wkpf_strict");
-    expectl(gcfg->log_opts, tcfg.log_opts, "log_opts");
-    expectl(gcfg->udp_cksum_mode, tcfg.udp_cksum_mode, "udp_cksum_mode");
-    expectl(gcfg->tun_up, tcfg.tun_up, "tun_up");
+    expects(gcfg.tundev, tcfg.tundev, IFNAMSIZ, "tundev");
+    expects(gcfg.data_dir, tcfg.data_dir, 512, "data_dir");
+    expects(gcfg.map_file, tcfg.map_file, 512, "map_file");
+    expectl(gcfg.local_addr4.s_addr, tcfg.local_addr4.s_addr, "local_addr4");
+    expectl(gcfg.local_addr6.s6_addr32[0],tcfg.local_addr6.s6_addr32[0], "local_addr6[0]");
+    expectl(gcfg.local_addr6.s6_addr32[1],tcfg.local_addr6.s6_addr32[1], "local_addr6[1]");
+    expectl(gcfg.local_addr6.s6_addr32[2],tcfg.local_addr6.s6_addr32[2], "local_addr6[2]");
+    expectl(gcfg.local_addr6.s6_addr32[3],tcfg.local_addr6.s6_addr32[3], "local_addr6[3]");
+    expectl(gcfg.dyn_min_lease, tcfg.dyn_min_lease, "dyn_min_lease");
+    expectl(gcfg.dyn_max_lease, tcfg.dyn_max_lease, "dyn_max_lease");
+    expectl(gcfg.max_commit_delay, tcfg.max_commit_delay, "max_commit_delay");
+    expectl(gcfg.hash_bits,tcfg.hash_bits, "hash_bits");
+    expectl(gcfg.cache_size,tcfg.cache_size, "cache_size");
+    expectl(gcfg.ipv6_offlink_mtu,tcfg.ipv6_offlink_mtu, "ipv6_offlink_mtu");
+    expectl(gcfg.workers,tcfg.workers, "workers");
+    expectl(gcfg.mtu,tcfg.mtu, "mtu");
+    expectl(gcfg.wkpf_strict, tcfg.wkpf_strict, "wkpf_strict");
+    expectl(gcfg.log_opts, tcfg.log_opts, "log_opts");
+    expectl(gcfg.udp_cksum_mode, tcfg.udp_cksum_mode, "udp_cksum_mode");
+    expectl(gcfg.tun_up, tcfg.tun_up, "tun_up");
 
     /* Pointers in gcfg which are not touched by conffile.c */
-    expectl(gcfg->tun_fd, 0, "tun_fd");
+    expectl(gcfg.tun_fd, 0, "tun_fd");
 
     int count = 0, expect_count = 0;
 	struct list_head *entry;
     char addrbuf[64], addrbuf2[64];
     char linebuf[512], namebuf[64];
     /* Iterate over map4 list and compare length */
-	list_for_each(entry, &gcfg->map4_list) {
+	list_for_each(entry, &gcfg.map4_list) {
         count++;
     }
     for(expect_count = 0; tmap4[expect_count];expect_count++) ;
@@ -118,7 +114,7 @@ void test_config_compare(void) {
     if(count == expect_count) {
         count = 0;
         /* Compare contents of lists as strings */
-        list_for_each(entry, &gcfg->map4_list) {
+        list_for_each(entry, &gcfg.map4_list) {
             struct map4 *s4;
             sprintf(namebuf,"map4[%d]",count);
             s4 = list_entry(entry, struct map4, list);
@@ -133,7 +129,7 @@ void test_config_compare(void) {
 
     /* Iterate over map6 list and compare length */
     count = 0;
-	list_for_each(entry, &gcfg->map6_list) {
+	list_for_each(entry, &gcfg.map6_list) {
         count++;
     }
     for(expect_count = 0; tmap6[expect_count];expect_count++) ;
@@ -143,7 +139,7 @@ void test_config_compare(void) {
     if(count == expect_count) {
         count = 0;
         /* Compare contents of lists as strings */
-        list_for_each(entry, &gcfg->map6_list) {
+        list_for_each(entry, &gcfg.map6_list) {
             struct map6 *s6;
             sprintf(namebuf,"map6[%d]",count);
             s6 = list_entry(entry, struct map6, list);
@@ -159,10 +155,10 @@ void test_config_compare(void) {
 
     /* Iterate over ip4 + ip6 list and compare length */
     count = 0;
-	list_for_each(entry, &gcfg->tun_ip4_list) {
+	list_for_each(entry, &gcfg.tun_ip4_list) {
         count++;
     }
-	list_for_each(entry, &gcfg->tun_ip6_list) {
+	list_for_each(entry, &gcfg.tun_ip6_list) {
         count++;
     }
     for(expect_count = 0; tun_ip[expect_count];expect_count++) ;
@@ -173,7 +169,7 @@ void test_config_compare(void) {
     if(count == expect_count) {
         count = 0;
         /* Compare contents of ip4 list as strings */
-        list_for_each(entry, &gcfg->tun_ip4_list) {
+        list_for_each(entry, &gcfg.tun_ip4_list) {
             struct tun_ip4 *ip4;
             sprintf(namebuf,"tun_ip[%d]",count);
             ip4 = list_entry(entry, struct tun_ip4, list);
@@ -185,7 +181,7 @@ void test_config_compare(void) {
         }
 
         /* Compare contents of ip6 list as strings */
-        list_for_each(entry, &gcfg->tun_ip6_list) {
+        list_for_each(entry, &gcfg.tun_ip6_list) {
             struct tun_ip6 *ip6;
             sprintf(namebuf,"tun_ip[%d]",count);
             ip6 = list_entry(entry, struct tun_ip6, list);
@@ -199,10 +195,10 @@ void test_config_compare(void) {
 
     /* Iterate over rt4 and rt6 lists and compare length */
     count = 0;
-	list_for_each(entry, &gcfg->tun_rt4_list) {
+	list_for_each(entry, &gcfg.tun_rt4_list) {
         count++;
     }
-	list_for_each(entry, &gcfg->tun_rt6_list) {
+	list_for_each(entry, &gcfg.tun_rt6_list) {
         count++;
     }
     for(expect_count = 0; tun_route[expect_count];expect_count++) ;
@@ -212,7 +208,7 @@ void test_config_compare(void) {
     if(count == expect_count) {
         count = 0;
         /* Compare contents of ip4 list as strings */
-        list_for_each(entry, &gcfg->tun_rt4_list) {
+        list_for_each(entry, &gcfg.tun_rt4_list) {
             struct tun_ip4 *ip4;
             sprintf(namebuf,"tun_route[%d]",count);
             ip4 = list_entry(entry, struct tun_ip4, list);
@@ -224,7 +220,7 @@ void test_config_compare(void) {
         }
 
         /* Compare contents of ip6 list as strings */
-        list_for_each(entry, &gcfg->tun_rt6_list) {
+        list_for_each(entry, &gcfg.tun_rt6_list) {
             struct tun_ip6 *ip6;
             sprintf(namebuf,"tun_route[%d]",count);
             ip6 = list_entry(entry, struct tun_ip6, list);
@@ -237,11 +233,11 @@ void test_config_compare(void) {
     }
 
     /* Structs */
-    //expect(gcfg->map6_list == tcfg.map6_list, "map6_list");
-    //expect(gcfg->map4_list == tcfg.map4_list, "map4_list");
-    //expect(gcfg->dynamic_pool == tcfg.dynamic_pool, "dynamic_pool");
-    //expect(gcfg->hash_table4 == tcfg.hash_table4, "hash_table4");
-    //expect(gcfg->hash_table6 == tcfg.hash_table6, "hash_table6");
+    //expect(gcfg.map6_list == tcfg.map6_list, "map6_list");
+    //expect(gcfg.map4_list == tcfg.map4_list, "map4_list");
+    //expect(gcfg.dynamic_pool == tcfg.dynamic_pool, "dynamic_pool");
+    //expect(gcfg.hash_table4 == tcfg.hash_table4, "hash_table4");
+    //expect(gcfg.hash_table6 == tcfg.hash_table6, "hash_table6");
 
 }
 
@@ -250,8 +246,6 @@ void test_config_compare(void) {
  */
 void test_config_init(void) {
     printf("TEST CASES FOR CONFIG INIT\n");
-    /* Setup gcfg invalid */
-    gcfg = NULL;
 
     /* Call config_init */
     config_init();
@@ -300,7 +294,6 @@ void test_config_read(void) {
     /* Example config */
     conffile = "tayga.conf.example";
     if(!print_fail_only) printf("TEST CASE: example conf file\n");
-    free(gcfg);
     config_init();
     expect(!config_read(conffile),"Passed");
     tcfg.wkpf_strict = 0;
@@ -324,7 +317,6 @@ void test_config_read(void) {
     testcase = "#this file is empty\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(!config_read(conffile),"Passed");
     tcfg.data_dir[0] = 0;
@@ -343,7 +335,6 @@ void test_config_read(void) {
     testcase = "tun-device nat64\ntun-device clat";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -355,7 +346,6 @@ void test_config_read(void) {
     testcase = "ipv4-addr 192.168.255.1\nipv4-addr 192.168.255.2\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -367,7 +357,6 @@ void test_config_read(void) {
     testcase = "ipv4-addr hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -379,7 +368,6 @@ void test_config_read(void) {
     testcase = "ipv4-addr 127.0.1.1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -391,7 +379,6 @@ void test_config_read(void) {
     testcase = "ipv6-addr 2001:db8::1\nipv6-addr 2001:db8::2";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -403,7 +390,6 @@ void test_config_read(void) {
     testcase = "ipv6-addr 2001:db8::hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -415,7 +401,6 @@ void test_config_read(void) {
     testcase = "ipv6-addr fe80::1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -427,7 +412,6 @@ void test_config_read(void) {
     testcase = "prefix 64:ff9b::6/96\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -439,7 +423,6 @@ void test_config_read(void) {
     testcase = "prefix fe80::/96\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -451,7 +434,6 @@ void test_config_read(void) {
     testcase = "prefix 64:ff9b::/95\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -463,7 +445,6 @@ void test_config_read(void) {
     testcase = "prefix 64:ff9b::/96\nprefix 64:ff9b:1::/96";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -475,7 +456,6 @@ void test_config_read(void) {
     testcase = "wkpf-strict hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -487,7 +467,6 @@ void test_config_read(void) {
     testcase = "udp-cksum-mode hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -499,7 +478,6 @@ void test_config_read(void) {
     testcase = "map 192.168.fe.0 2001:db8::3\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -511,7 +489,6 @@ void test_config_read(void) {
     testcase = "map 192.168.255.0 2001:db8::hi\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -523,7 +500,6 @@ void test_config_read(void) {
     testcase = "map 192.168.254.0/24 2001:db8::/116\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -535,7 +511,6 @@ void test_config_read(void) {
     testcase = "map 233.0.1.1/24 2001:db8::/120\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -547,7 +522,6 @@ void test_config_read(void) {
     testcase = "map 192.168.0.0/24 fe80::/120\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -559,7 +533,6 @@ void test_config_read(void) {
     testcase = "map 192.168.254.0/24 2001:db8::/120\nmap 192.168.254.0/24 2001:db8::/120\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -571,7 +544,6 @@ void test_config_read(void) {
     testcase = "map 192.168.253.0/24 2001:db8::/120\nmap 192.168.254.0/24 2001:db8::/120\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -583,7 +555,6 @@ void test_config_read(void) {
     testcase = "dynamic-pool 192.168.255.0/24\ndynamic-pool 192.168.254.0/24\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -595,7 +566,6 @@ void test_config_read(void) {
     testcase = "dynamic-pool 192.268.254.0/24\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -607,7 +577,6 @@ void test_config_read(void) {
     testcase = "dynamic-pool 225.0.0.1/16\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -619,7 +588,6 @@ void test_config_read(void) {
     testcase = "dynamic-pool 192.168.100.1/32\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -631,7 +599,6 @@ void test_config_read(void) {
     testcase = "data-dir /var/lib/tayga\ndata-dir /var/spool/tayga\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -643,7 +610,6 @@ void test_config_read(void) {
     testcase = "data-dir var/spool/tayga\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -655,7 +621,6 @@ void test_config_read(void) {
     testcase = "map-file /var/lib/tayga/static.map\nmap-file static.map\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -667,7 +632,6 @@ void test_config_read(void) {
     testcase = "offlink-mtu 1500\nofflink-mtu 1440\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -679,7 +643,6 @@ void test_config_read(void) {
     testcase = "offlink-mtu 1200\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -691,7 +654,6 @@ void test_config_read(void) {
     testcase = "offlink-mtu 120000\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -703,7 +665,6 @@ void test_config_read(void) {
     testcase = "offlink-mtu 0x1235\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -716,7 +677,6 @@ void test_config_read(void) {
     testcase = "workers 6\nworkesr 4\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -728,7 +688,6 @@ void test_config_read(void) {
     testcase = "workers -1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -740,7 +699,6 @@ void test_config_read(void) {
     testcase = "workers 12000\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -753,7 +711,6 @@ void test_config_read(void) {
     testcase = "workers 0\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -767,7 +724,6 @@ void test_config_read(void) {
     testcase = "workers 0x6\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -779,7 +735,6 @@ void test_config_read(void) {
     testcase = "log drop\nlog reject\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -791,7 +746,6 @@ void test_config_read(void) {
     testcase = "log something\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -804,7 +758,6 @@ void test_config_read(void) {
     testcase = "tun-up hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -816,7 +769,6 @@ void test_config_read(void) {
     testcase = "tun-up\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -828,7 +780,6 @@ void test_config_read(void) {
     testcase = "tun-ip\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -840,7 +791,6 @@ void test_config_read(void) {
     testcase = "tun-ip hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -852,7 +802,6 @@ void test_config_read(void) {
     testcase = "tun-ip 2001:db8::1/129\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -864,7 +813,6 @@ void test_config_read(void) {
     testcase = "tun-ip 2001:db8::1/-1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -876,7 +824,6 @@ void test_config_read(void) {
     testcase = "tun-ip 2001:db8::1/hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -889,7 +836,6 @@ void test_config_read(void) {
     testcase = "tun-ip 192.168.0.b\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -901,7 +847,6 @@ void test_config_read(void) {
     testcase = "tun-ip 192.168.0\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -913,7 +858,6 @@ void test_config_read(void) {
     testcase = "tun-ip 192.168.0.0/-1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -925,7 +869,6 @@ void test_config_read(void) {
     testcase = "tun-ip 192.168.0.0/33\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -937,7 +880,6 @@ void test_config_read(void) {
     testcase = "tun-route hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -949,7 +891,6 @@ void test_config_read(void) {
     testcase = "tun-route 2001:db8::1/129\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -961,7 +902,6 @@ void test_config_read(void) {
     testcase = "tun-route 2001:db8::1/-1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -973,7 +913,6 @@ void test_config_read(void) {
     testcase = "tun-route 2001:db8::1/hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -986,7 +925,6 @@ void test_config_read(void) {
     testcase = "tun-route 192.168.0.b\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -998,7 +936,6 @@ void test_config_read(void) {
     testcase = "tun-route 192.168.0\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1010,7 +947,6 @@ void test_config_read(void) {
     testcase = "tun-route 192.168.0.0/-1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1022,7 +958,6 @@ void test_config_read(void) {
     testcase = "tun-route 192.168.0.0/33\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1034,7 +969,6 @@ void test_config_read(void) {
     testcase = "unbknown 4\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1046,7 +980,6 @@ void test_config_read(void) {
     testcase = "log a b c d e f g h i j k l m n o p\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1058,7 +991,6 @@ void test_config_read(void) {
     testcase = "ipv4-addr 192.168.0.0 192.168.1.0\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(config_read(conffile),"Failed");
 
@@ -1091,9 +1023,7 @@ void test_config_read(void) {
     if(!fd) return;
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
-    expect((long)gcfg,"config_init");
     expect(!config_read(conffile),"Passed");
     strcpy(tcfg.data_dir,"/var/lib/tayga");
     strcpy(tcfg.tundev,"nat64");
@@ -1139,7 +1069,6 @@ void test_config_validate() {
 
     /* No config loading has been done */
     if(!print_fail_only) printf("TEST CASE: no config loaded\n");
-    free(gcfg);
     config_init();
     expect(config_validate(),"Validate Failed");
 
@@ -1151,7 +1080,6 @@ void test_config_validate() {
     testcase = "#hello\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     expect(!config_read(conffile),"Read Passed");
     expect(config_validate(),"Validate Failed");
@@ -1166,7 +1094,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1183,7 +1110,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1201,7 +1127,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1220,7 +1145,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1238,7 +1162,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1257,7 +1180,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1274,7 +1196,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1291,7 +1212,6 @@ void test_config_validate() {
         "ipv6-addr 2001:db8::1\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
@@ -1309,17 +1229,16 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 1;
     expect(!config_read(conffile),"Read Passed");
     /* Combined with offlink MTU test*/
-    gcfg->ipv6_offlink_mtu = 0;
+    gcfg.ipv6_offlink_mtu = 0;
     expect(!config_validate(),"Validate Passed");
-    expectl(gcfg->ipv6_offlink_mtu,MTU_MIN,"Min MTU");
+    expectl(gcfg.ipv6_offlink_mtu,MTU_MIN,"Min MTU");
     expectl(getenv_case,0,"Getenv Called");
     /* Combined with STATE_DIRECTORY test */
-    expects(gcfg->data_dir,"/var/lib/tayga",15,"data_dir");
+    expects(gcfg.data_dir,"/var/lib/tayga",15,"data_dir");
 
     /* state directory not absolute */
     if(!print_fail_only) printf("TEST CASE: state dir not absolute\n");
@@ -1332,7 +1251,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 2;
     expect(!config_read(conffile),"Read Passed");
@@ -1350,7 +1268,6 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 3;
     expect(!config_read(conffile),"Read Passed");
@@ -1368,13 +1285,12 @@ void test_config_validate() {
         "tun-device nat64\n";
     fwrite(testcase,strlen(testcase),1,fd);
     fclose(fd);
-    free(gcfg);
     config_init();
     getenv_case = 4;
     expect(!config_read(conffile),"Read Passed");
     expect(!config_validate(),"Validate Passed");
     expectl(getenv_case,0,"Getenv Called");
-    expects(gcfg->data_dir,"/var/lib/tayga",15,"data_dir");
+    expects(gcfg.data_dir,"/var/lib/tayga",15,"data_dir");
 }
 
 int main(void) {

--- a/tun.c
+++ b/tun.c
@@ -286,8 +286,8 @@ int tun_setup(int do_mktun, int do_rmtun)
 	struct ifreq ifr;
 	int fd;
 
-	gcfg->tun_fd = open("/dev/net/tun", O_RDWR);
-	if (gcfg->tun_fd < 0) {
+	gcfg.tun_fd = open("/dev/net/tun", O_RDWR);
+	if (gcfg.tun_fd < 0) {
 		slog(LOG_CRIT, "Unable to open /dev/net/tun, aborting: %s\n",
 				strerror(errno));
 		return ERROR_REJECT;
@@ -295,48 +295,48 @@ int tun_setup(int do_mktun, int do_rmtun)
 
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TUN | IFF_MULTI_QUEUE;
-	strcpy(ifr.ifr_name, gcfg->tundev);
-	if (ioctl(gcfg->tun_fd, TUNSETIFF, &ifr) < 0) {
+	strcpy(ifr.ifr_name, gcfg.tundev);
+	if (ioctl(gcfg.tun_fd, TUNSETIFF, &ifr) < 0) {
 		slog(LOG_CRIT, "Unable to attach tun device %s, aborting: "
-				"%s\n", gcfg->tundev, strerror(errno));
+				"%s\n", gcfg.tundev, strerror(errno));
 		return ERROR_REJECT;
 	}
 
 	if (do_mktun) {
-		if (ioctl(gcfg->tun_fd, TUNSETPERSIST, 1) < 0) {
+		if (ioctl(gcfg.tun_fd, TUNSETPERSIST, 1) < 0) {
 			slog(LOG_CRIT, "Unable to set persist flag on %s, "
-					"aborting: %s\n", gcfg->tundev,
+					"aborting: %s\n", gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 		}
-		if (ioctl(gcfg->tun_fd, TUNSETOWNER, 0) < 0) {
+		if (ioctl(gcfg.tun_fd, TUNSETOWNER, 0) < 0) {
 			slog(LOG_CRIT, "Unable to set owner on %s, "
-					"aborting: %s\n", gcfg->tundev,
+					"aborting: %s\n", gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 		}
-		if (ioctl(gcfg->tun_fd, TUNSETGROUP, 0) < 0) {
+		if (ioctl(gcfg.tun_fd, TUNSETGROUP, 0) < 0) {
 			slog(LOG_CRIT, "Unable to set group on %s, "
-					"aborting: %s\n", gcfg->tundev,
+					"aborting: %s\n", gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 		}
 		slog(LOG_NOTICE, "Created persistent tun device %s\n",
-				gcfg->tundev);
+				gcfg.tundev);
 		return 0;
 	} else if (do_rmtun) {
-		if (ioctl(gcfg->tun_fd, TUNSETPERSIST, 0) < 0) {
+		if (ioctl(gcfg.tun_fd, TUNSETPERSIST, 0) < 0) {
 			slog(LOG_CRIT, "Unable to clear persist flag on %s, "
-					"aborting: %s\n", gcfg->tundev,
+					"aborting: %s\n", gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 		}
 		slog(LOG_NOTICE, "Removed persistent tun device %s\n",
-				gcfg->tundev);
+				gcfg.tundev);
 		return 0;
 	}
 
-	if(set_nonblock(gcfg->tun_fd)) return ERROR_REJECT;
+	if(set_nonblock(gcfg.tun_fd)) return ERROR_REJECT;
 
 	fd = socket(PF_INET, SOCK_DGRAM, 0);
 	if (fd < 0) {
@@ -347,7 +347,7 @@ int tun_setup(int do_mktun, int do_rmtun)
 
 	/* Query MTU from tun adapter */
 	memset(&ifr, 0, sizeof(ifr));
-	strcpy(ifr.ifr_name, gcfg->tundev);
+	strcpy(ifr.ifr_name, gcfg.tundev);
 	if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
 		slog(LOG_CRIT, "Unable to query MTU, aborting: %s\n",
 				strerror(errno));
@@ -356,94 +356,94 @@ int tun_setup(int do_mktun, int do_rmtun)
 	close(fd);
 
 	/* MTU is less than 1280, not allowed */
-	gcfg->mtu = ifr.ifr_mtu;
-	if(gcfg->mtu < MTU_MIN) {
+	gcfg.mtu = ifr.ifr_mtu;
+	if(gcfg.mtu < MTU_MIN) {
 		slog(LOG_CRIT, "MTU of %d is too small, must be at least %d\n",
-				gcfg->mtu, MTU_MIN);
+				gcfg.mtu, MTU_MIN);
 		return ERROR_REJECT;
 	}
 
-	slog(LOG_INFO, "Using tun device %s with MTU %d\n", gcfg->tundev,
-			gcfg->mtu);
+	slog(LOG_INFO, "Using tun device %s with MTU %d\n", gcfg.tundev,
+			gcfg.mtu);
 
 	/* Get our own device ID for the tun setup operations */
-	int ifidx = if_nametoindex(gcfg->tundev);
+	int ifidx = if_nametoindex(gcfg.tundev);
 
     if (ifidx == 0) {
-		slog(LOG_INFO, "Failed to get if idx from tun device %s\n",gcfg->tundev);
+		slog(LOG_INFO, "Failed to get if idx from tun device %s\n",gcfg.tundev);
 		return ERROR_REJECT;
     }
 	/* Bring tun device up */
-	if(gcfg->tun_up) {
+	if(gcfg.tun_up) {
 		if(netlink_set_if_flags(ifidx,IFF_UP,IFF_UP)) return ERROR_REJECT;
-		slog(LOG_INFO, "Tun device %s is UP\n",gcfg->tundev);
+		slog(LOG_INFO, "Tun device %s is UP\n",gcfg.tundev);
 	}
 
 	/* Add IPs to the tun dev */
 	char addrbuf[INET6_ADDRSTRLEN];
 	struct list_head *entry;
-	list_for_each(entry, &gcfg->tun_ip4_list) {
+	list_for_each(entry, &gcfg.tun_ip4_list) {
 		struct tun_ip4 *ip4;
 		ip4 = list_entry(entry, struct tun_ip4, list);
 		if(netlink_addr_modify(ifidx,AF_INET,&ip4->addr,
 				ip4->prefix_len,1)) return ERROR_REJECT;
 		slog(LOG_INFO, "Added IPv4 address %s/%d to tun device %s\n",
 			inet_ntop(AF_INET,&ip4->addr,addrbuf,INET6_ADDRSTRLEN),
-			ip4->prefix_len,gcfg->tundev);
+			ip4->prefix_len,gcfg.tundev);
 	}
-	list_for_each(entry, &gcfg->tun_ip6_list) {
+	list_for_each(entry, &gcfg.tun_ip6_list) {
 		struct tun_ip6 *ip6;
 		ip6 = list_entry(entry, struct tun_ip6, list);
 		if(netlink_addr_modify(ifidx,AF_INET6,&ip6->addr,
 				ip6->prefix_len,1)) return ERROR_REJECT;
 		slog(LOG_INFO, "Added IPv6 address %s/%d to tun device %s\n",
 			inet_ntop(AF_INET6,&ip6->addr,addrbuf,INET6_ADDRSTRLEN),
-			ip6->prefix_len,gcfg->tundev);
+			ip6->prefix_len,gcfg.tundev);
 	}
 
 	/* Add routes to the tun dev */
-	list_for_each(entry, &gcfg->tun_rt4_list) {
+	list_for_each(entry, &gcfg.tun_rt4_list) {
 		struct tun_ip4 *ip4;
 		ip4 = list_entry(entry, struct tun_ip4, list);
 		if(netlink_route_dev_modify(ifidx,AF_INET,&ip4->addr,
 				ip4->prefix_len,1)) return ERROR_REJECT;
 		slog(LOG_INFO, "Added IPv4 route %s/%d to tun device %s\n",
 			inet_ntop(AF_INET,&ip4->addr,addrbuf,INET6_ADDRSTRLEN),
-			ip4->prefix_len,gcfg->tundev);
+			ip4->prefix_len,gcfg.tundev);
 	}
-	list_for_each(entry, &gcfg->tun_rt6_list) {
+	list_for_each(entry, &gcfg.tun_rt6_list) {
 		struct tun_ip6 *ip6;
 		ip6 = list_entry(entry, struct tun_ip6, list);
 		if(netlink_route_dev_modify(ifidx,AF_INET6,&ip6->addr,
 				ip6->prefix_len,1)) return ERROR_REJECT;
 		slog(LOG_INFO, "Added IPv6 route %s/%d to tun device %s\n",
 			inet_ntop(AF_INET6,&ip6->addr,addrbuf,INET6_ADDRSTRLEN),
-			ip6->prefix_len,gcfg->tundev);
+			ip6->prefix_len,gcfg.tundev);
 	}
 
 	/* Setup multiqueue additional queues */
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TUN | IFF_MULTI_QUEUE;
-	strcpy(ifr.ifr_name, gcfg->tundev);
-	for(int i = 0; i < gcfg->workers; i++) {
-		gcfg->tun_fd_addl[i] = open("/dev/net/tun", O_RDWR);
-		if (gcfg->tun_fd_addl[i] < 0) {
+	strcpy(ifr.ifr_name, gcfg.tundev);
+	for(int i = 0; i < gcfg.workers; i++) {
+		gcfg.tun_fd_addl[i] = open("/dev/net/tun", O_RDWR);
+		if (gcfg.tun_fd_addl[i] < 0) {
 			slog(LOG_CRIT, "Unable to open /dev/net/tun, aborting: %s\n",
 					strerror(errno));
 			exit(1);
 		}
-		if (ioctl(gcfg->tun_fd_addl[i], TUNSETIFF, &ifr) < 0) {
+		if (ioctl(gcfg.tun_fd_addl[i], TUNSETIFF, &ifr) < 0) {
 			slog(LOG_CRIT, "Unable to attach tun device %s, aborting: "
-					"%s\n", gcfg->tundev, strerror(errno));
+					"%s\n", gcfg.tundev, strerror(errno));
 			exit(1);
 		}
 	}
 
 	/* Disable queue of main tun if we have >0 workers */
-	if(gcfg->workers > 0) {
+	if(gcfg.workers > 0) {
 		memset(&ifr, 0, sizeof(ifr));
 		ifr.ifr_flags = IFF_DETACH_QUEUE;
-		if(ioctl(gcfg->tun_fd, TUNSETQUEUE, (void *)&ifr)) slog(LOG_CRIT,"Unable to detach main queue\n");
+		if(ioctl(gcfg.tun_fd, TUNSETQUEUE, (void *)&ifr)) slog(LOG_CRIT,"Unable to detach main queue\n");
 	}
 
 	//No error on setup
@@ -458,7 +458,7 @@ int tun_setup(int do_mktun, int do_rmtun)
 	int fd, do_rename = 0, multi_af;
 	char devname[64];
 
-	if (strncmp(gcfg->tundev, "tun", 3))
+	if (strncmp(gcfg.tundev, "tun", 3))
 		do_rename = 1;
 
 	if ((do_mktun || do_rmtun) && do_rename)
@@ -469,10 +469,10 @@ int tun_setup(int do_mktun, int do_rmtun)
 		return ERROR_REJECT;
 	}
 
-	snprintf(devname, sizeof(devname), "/dev/%s", do_rename ? "tun" : gcfg->tundev);
+	snprintf(devname, sizeof(devname), "/dev/%s", do_rename ? "tun" : gcfg.tundev);
 
-	gcfg->tun_fd = open(devname, O_RDWR);
-	if (gcfg->tun_fd < 0) {
+	gcfg.tun_fd = open(devname, O_RDWR);
+	if (gcfg.tun_fd < 0) {
 		slog(LOG_CRIT, "Unable to open %s, aborting: %s\n",
 				devname, strerror(errno));
 		return ERROR_REJECT;
@@ -480,12 +480,12 @@ int tun_setup(int do_mktun, int do_rmtun)
 
 	if (do_mktun) {
 		slog(LOG_NOTICE, "Created persistent tun device %s\n",
-				gcfg->tundev);
+				gcfg.tundev);
 		return ERROR_NONE;
 	} else if (do_rmtun) {
 
 		/* Close socket before removal */
-		close(gcfg->tun_fd);
+		close(gcfg.tun_fd);
 
 		fd = socket(PF_INET, SOCK_DGRAM, 0);
 		if (fd < 0) {
@@ -495,32 +495,32 @@ int tun_setup(int do_mktun, int do_rmtun)
 		}
 
 		memset(&ifr, 0, sizeof(ifr));
-		strcpy(ifr.ifr_name, gcfg->tundev);
+		strcpy(ifr.ifr_name, gcfg.tundev);
 		if (ioctl(fd, SIOCIFDESTROY, &ifr) < 0) {
 			slog(LOG_CRIT, "Unable to destroy interface %s, aborting: %s\n",
-					gcfg->tundev, strerror(errno));
+					gcfg.tundev, strerror(errno));
 			return ERROR_REJECT;
 		}
 
 		close(fd);
 
 		slog(LOG_NOTICE, "Removed persistent tun device %s\n",
-				gcfg->tundev);
+				gcfg.tundev);
 		return ERROR_NONE;
 	}
 
 	/* Set multi-AF mode */
 	multi_af = 1;
-	if (ioctl(gcfg->tun_fd, TUNSIFHEAD, &multi_af) < 0) {
+	if (ioctl(gcfg.tun_fd, TUNSIFHEAD, &multi_af) < 0) {
 			slog(LOG_CRIT, "Unable to set multi-AF on %s, "
-					"aborting: %s\n", gcfg->tundev,
+					"aborting: %s\n", gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 	}
 
-	slog(LOG_CRIT, "Multi-AF mode set on %s\n", gcfg->tundev);
+	slog(LOG_CRIT, "Multi-AF mode set on %s\n", gcfg.tundev);
 
-	if(set_nonblock(gcfg->tun_fd)) return ERROR_REJECT;
+	if(set_nonblock(gcfg.tun_fd)) return ERROR_REJECT;
 
 	fd = socket(PF_INET, SOCK_DGRAM, 0);
 	if (fd < 0) {
@@ -531,18 +531,18 @@ int tun_setup(int do_mktun, int do_rmtun)
 
 	if (do_rename) {
 		memset(&ifr, 0, sizeof(ifr));
-		strcpy(ifr.ifr_name, fdevname(gcfg->tun_fd));
-		ifr.ifr_data = gcfg->tundev;
+		strcpy(ifr.ifr_name, fdevname(gcfg.tun_fd));
+		ifr.ifr_data = gcfg.tundev;
 		if (ioctl(fd, SIOCSIFNAME, &ifr) < 0) {
 			slog(LOG_CRIT, "Unable to rename interface %s to %s, aborting: %s\n",
-					fdevname(gcfg->tun_fd), gcfg->tundev,
+					fdevname(gcfg.tun_fd), gcfg.tundev,
 					strerror(errno));
 			return ERROR_REJECT;
 		}
 	}
 
 	memset(&ifr, 0, sizeof(ifr));
-	strcpy(ifr.ifr_name, gcfg->tundev);
+	strcpy(ifr.ifr_name, gcfg.tundev);
 	if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
 		slog(LOG_CRIT, "Unable to query MTU, aborting: %s\n",
 				strerror(errno));
@@ -550,10 +550,10 @@ int tun_setup(int do_mktun, int do_rmtun)
 	}
 	close(fd);
 
-	gcfg->mtu = ifr.ifr_mtu;
+	gcfg.mtu = ifr.ifr_mtu;
 
-	slog(LOG_INFO, "Using tun device %s with MTU %d\n", gcfg->tundev,
-			gcfg->mtu);
+	slog(LOG_INFO, "Using tun device %s with MTU %d\n", gcfg.tundev,
+			gcfg.mtu);
     return ERROR_NONE;
 }
 #endif


### PR DESCRIPTION
Part of ongoing janitorial work. I plan to do more, but in the interest of not making these impossible to review... I try to keep my commits sensible, so do look at them individually if you prefer (squashing is terrible etc. etc.).

The only user-visible change is a warning when eg. `--syslog` is combined with `--mktun`/`--rmtun`. Erroring out has the potential to break old setups unexpectedly, so I didn't.

EDIT: Also when positional arguments are included. Silently ignoring them was the previous behavior, now we're just loudly ignoring them.

Note: Before doing a 1.0, it may be a good idea to change the command line syntax to something like `tayga mktun ...`, `tayga rmtun ...`, `tayga start ...`. Not doing so could make argument parsing really annoying down the line.